### PR TITLE
Fixing callbacks in example

### DIFF
--- a/examples/callbacks.php
+++ b/examples/callbacks.php
@@ -51,7 +51,7 @@ $loader       = new Finite\Loader\ArrayLoader([
         'before' => [
             [
                 'from' => '-proposed',
-                'do' => function(\Finite\Event\TransitionEvent $e) {
+                'do' => function(Finite\StatefulInterface $document, \Finite\Event\TransitionEvent $e) {
                     echo 'Applying transition '.$e->getTransition()->getName(), "\n";
                 }
             ],


### PR DESCRIPTION
Added extra param to callback example to avoid fatal ArgumentError
