### PR TITLE
Remove StatefulInterface from type hint

### DIFF
--- a/src/Finite/Context.php
+++ b/src/Finite/Context.php
@@ -3,6 +3,7 @@
 namespace Finite;
 
 use Finite\Factory\FactoryInterface;
+use Finite\StateMachine\StateMachine;
 
 /**
  * The Finite context.
@@ -26,57 +27,57 @@ class Context
     }
 
     /**
-     * @param StatefulInterface $object
-     * @param string            $graph
+     * @param object $object
+     * @param string $graph
      *
      * @return string
      */
-    public function getState(StatefulInterface $object, $graph = 'default')
+    public function getState($object, $graph = 'default')
     {
         return $this->getStateMachine($object, $graph)->getCurrentState()->getName();
     }
 
     /**
-     * @param StatefulInterface $object
-     * @param string            $graph
+     * @param object $object
+     * @param string $graph
      *
      * @return array<string>
      */
-    public function getTransitions(StatefulInterface $object, $graph = 'default')
+    public function getTransitions($object, $graph = 'default')
     {
         return $this->getStateMachine($object, $graph)->getCurrentState()->getTransitions();
     }
 
     /**
-     * @param StatefulInterface $object
-     * @param string            $graph
+     * @param object $object
+     * @param string $graph
      *
      * @return array<string>
      */
-    public function getProperties(StatefulInterface $object, $graph = 'default')
+    public function getProperties($object, $graph = 'default')
     {
         return $this->getStateMachine($object, $graph)->getCurrentState()->getProperties();
     }
 
     /**
-     * @param StatefulInterface $object
-     * @param string            $property
-     * @param string            $graph
+     * @param object $object
+     * @param string $property
+     * @param string $graph
      *
      * @return bool
      */
-    public function hasProperty(StatefulInterface $object, $property, $graph = 'default')
+    public function hasProperty($object, $property, $graph = 'default')
     {
         return $this->getStateMachine($object, $graph)->getCurrentState()->has($property);
     }
 
     /**
-     * @param StatefulInterface $object
-     * @param string            $graph
+     * @param object $object
+     * @param string $graph
      *
-     * @return \Finite\StateMachine\StateMachine
+     * @return StateMachine
      */
-    public function getStateMachine(StatefulInterface $object, $graph = 'default')
+    public function getStateMachine($object, $graph = 'default')
     {
         return $this->getFactory()->get($object, $graph);
     }

--- a/src/Finite/Extension/Twig/FiniteExtension.php
+++ b/src/Finite/Extension/Twig/FiniteExtension.php
@@ -3,7 +3,6 @@
 namespace Finite\Extension\Twig;
 
 use Finite\Context;
-use Finite\StatefulInterface;
 
 /**
  * The Finite Twig extension
@@ -40,58 +39,58 @@ class FiniteExtension extends \Twig_Extension
     }
 
     /**
-     * @param StatefulInterface $object
-     * @param string            $graph
+     * @param object $object
+     * @param string $graph
      *
      * @return string
      */
-    public function getFiniteState(StatefulInterface $object, $graph = 'default')
+    public function getFiniteState($object, $graph = 'default')
     {
         return $this->context->getState($object, $graph);
     }
 
     /**
-     * @param StatefulInterface $object
-     * @param string            $graph
+     * @param object $object
+     * @param string $graph
      *
      * @return array
      */
-    public function getFiniteTransitions(StatefulInterface $object, $graph = 'default')
+    public function getFiniteTransitions($object, $graph = 'default')
     {
         return $this->context->getTransitions($object, $graph);
     }
 
     /**
-     * @param StatefulInterface $object
-     * @param string            $graph
+     * @param object $object
+     * @param string $graph
      *
      * @return array
      */
-    public function getFiniteProperties(StatefulInterface $object, $graph = 'default')
+    public function getFiniteProperties($object, $graph = 'default')
     {
         return $this->context->getProperties($object, $graph);
     }
 
     /**
-     * @param StatefulInterface $object
-     * @param string            $property
-     * @param string            $graph
+     * @param object $object
+     * @param string $property
+     * @param string $graph
      *
      * @return bool
      */
-    public function hasFiniteProperty(StatefulInterface $object, $property, $graph = 'default')
+    public function hasFiniteProperty($object, $property, $graph = 'default')
     {
         return $this->context->hasProperty($object, $property, $graph);
     }
 
     /**
-     * @param StatefulInterface $object
-     * @param string            $transition
-     * @param string            $graph
+     * @param object $object
+     * @param string $transition
+     * @param string $graph
      *
      * @return bool|mixed
      */
-    public function canFiniteTransition(StatefulInterface $object, $transition, $graph = 'default')
+    public function canFiniteTransition($object, $transition, $graph = 'default')
     {
         return $this->context->getStateMachine($object, $graph)->can($transition);
     }

--- a/src/Finite/Factory/FactoryInterface.php
+++ b/src/Finite/Factory/FactoryInterface.php
@@ -2,6 +2,8 @@
 
 namespace Finite\Factory;
 
+use Finite\StateMachine\StateMachineInterface;
+
 /**
  * The base interface for Finite's State Machine Factory
  *
@@ -15,7 +17,7 @@ interface FactoryInterface
      * @param object $object
      * @param string $graph
      *
-     * @return \Finite\StateMachine\StateMachineInterface
+     * @return StateMachineInterface
      */
     public function get($object, $graph = 'default');
 }

--- a/src/Finite/StateMachine/StateMachine.php
+++ b/src/Finite/StateMachine/StateMachine.php
@@ -8,7 +8,6 @@ use Finite\Event\TransitionEvent;
 use Finite\Exception;
 use Finite\State\Accessor\PropertyPathStateAccessor;
 use Finite\State\Accessor\StateAccessorInterface;
-use Finite\StatefulInterface;
 use Finite\State\State;
 use Finite\State\StateInterface;
 use Finite\Transition\Transition;
@@ -26,7 +25,7 @@ class StateMachine implements StateMachineInterface
     /**
      * The stateful object
      *
-     * @var StatefulInterface
+     * @var object
      */
     protected $object;
 

--- a/src/Finite/StateMachine/StateMachineInterface.php
+++ b/src/Finite/StateMachine/StateMachineInterface.php
@@ -3,7 +3,6 @@
 namespace Finite\StateMachine;
 
 use Finite\State\Accessor\StateAccessorInterface;
-use Finite\StatefulInterface;
 use Finite\State\StateInterface;
 use Finite\Transition\TransitionInterface;
 
@@ -86,12 +85,12 @@ interface StateMachineInterface
     public function getStates();
 
     /**
-     * @param StatefulInterface $object
+     * @param object $object
      */
     public function setObject($object);
 
     /**
-     * @return StatefulInterface
+     * @return object
      */
     public function getObject();
 


### PR DESCRIPTION
To be fully compliant with the new property access strategy.
Otherwise, I can't use the TwigExtension for example.
