### PR TITLE
[Bundle] Add a way to remove callbacks via configuration

### DIFF
--- a/src/Finite/Bundle/FiniteBundle/DependencyInjection/Configuration.php
+++ b/src/Finite/Bundle/FiniteBundle/DependencyInjection/Configuration.php
@@ -94,12 +94,14 @@ class Configuration implements ConfigurationInterface
     {
         $callbacks
             ->arrayNode($type)
+                ->useAttributeAsKey('name')
                 ->prototype('array')
                     ->children()
                         ->scalarNode('on')->end()
                         ->variableNode('do')->end()
                         ->variableNode('from')->end()
                         ->variableNode('to')->end()
+                        ->scalarNode('disabled')->defaultValue(false)->end()
                     ->end()
                 ->end()
             ->end();

--- a/src/Finite/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtension.php
+++ b/src/Finite/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtension.php
@@ -28,6 +28,8 @@ class FiniteFiniteExtension extends Extension
         $factoryDefinition = $container->getDefinition('finite.factory');
 
         foreach ($config as $key => $stateMachineConfig) {
+            $stateMachineConfig = $this->removeDisabledCallbacks($stateMachineConfig);
+
             $definition = clone $container->getDefinition('finite.array_loader');
             $definition->addArgument($stateMachineConfig);
             $definition->addTag('finite.loader');
@@ -39,5 +41,29 @@ class FiniteFiniteExtension extends Extension
         }
 
         $container->removeDefinition('finite.array_loader');
+    }
+
+    /**
+     * Remove callback entries where index 'disabled' is set to true
+     *
+     * @param array $config
+     *
+     * @return array
+     */
+    protected function removeDisabledCallbacks(array $config)
+    {
+        if (!isset($config['callbacks'])) {
+            return $config;
+        }
+
+        foreach (array('before', 'after') as $position) {
+            foreach ($config['callbacks'][$position] as $i => $callback) {
+                if ($callback['disabled']) {
+                    unset($config['callbacks'][$position][$i]);
+                }
+            }
+        }
+
+        return $config;
     }
 }

--- a/tests/Finite/Test/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtensionTest.php
+++ b/tests/Finite/Test/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtensionTest.php
@@ -80,10 +80,10 @@ class FiniteFiniteExtensionTest extends \PHPUnit_Framework_TestCase
             ),
             'callbacks'     => array(
                 'before' => array(
-                    array('on' => '1_to_2', 'do' => array('@my.listener.service', 'on1To2'))
+                    'callback1' => array('on' => '1_to_2', 'do' => array('@my.listener.service', 'on1To2'), 'disabled' => false)
                 ),
                 'after'  => array(
-                    array('from' => '-state3', 'to' => array('state2', 'state3'), 'do' => array('@my.listener.service', 'on1To2'))
+                    'callback2' => array('from' => '-state3', 'to' => array('state2', 'state3'), 'do' => array('@my.listener.service', 'on1To2'), 'disabled' => false)
                 )
             )
         );
@@ -118,10 +118,11 @@ class FiniteFiniteExtensionTest extends \PHPUnit_Framework_TestCase
                     ),
                     'callbacks'   => array(
                         'before' => array(
-                            array('on' => '1_to_2', 'do' => array('@my.listener.service', 'on1To2'))
+                            'callback1' => array('on' => '1_to_2', 'do' => array('@my.listener.service', 'on1To2'))
                         ),
                         'after'  => array(
-                            array('from' => '-state3', 'to' => array('state2', 'state3'), 'do' => array('@my.listener.service', 'on1To2'))
+                            'callback2' => array('from' => '-state3', 'to' => array('state2', 'state3'), 'do' => array('@my.listener.service', 'on1To2')),
+                            'callback3' => array('disabled' => true)
                         )
                     )
                 )


### PR DESCRIPTION
Ref. https://github.com/Sylius/Sylius/pull/1447#issuecomment-42191671

With the bundle configuration, it was impossible to remove callbacks from one configuration file to another.
This PR adds this ability thanks to a `disabled` index (relevant only for the bundle, nothing to deal with the lib part of finite) and associative array for callbacks instead of a numeric one.

See this example of what can be achieved now.
First file loaded:

```
finite_finite:
    my_graph:
        ...
        callbacks:
            before:
                before1: { on: ..., do: ... }
```

Second file loaded:

```
finite_finite:
    my_graph:
        callbacks:
            before:
                before1: { disabled: true }
```

So that the callback `before1` won't be added to the loader configuration.
