### PR TITLE
Add lazy flag to avoid circular reference

### DIFF
--- a/src/Finite/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtension.php
+++ b/src/Finite/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtension.php
@@ -31,6 +31,7 @@ class FiniteFiniteExtension extends Extension
             $definition = clone $container->getDefinition('finite.array_loader');
             $definition->addArgument($stateMachineConfig);
             $definition->addTag('finite.loader');
+            $definition->setLazy(true);
 
             $serviceId  = 'finite.loader.'.$key;
             $container->setDefinition($serviceId, $definition);


### PR DESCRIPTION
So that if you have the package "ocramius/proxy-manager", it will create proxy services for loaders. This avoids the circular reference when you use a callback which have a dependency on the factory (because the factory needs the loaders which needs the callback).

If you don't have the package installed, it doesn't change anything, cf. http://symfony.com/doc/current/components/dependency_injection/lazy_services.html
