### PR TITLE
[WIP] Refactor CallbackHandler

### DIFF
--- a/examples/callbacks.php
+++ b/examples/callbacks.php
@@ -73,9 +73,19 @@ $loader       = new Finite\Loader\ArrayLoader(array(
 $loader->load($stateMachine);
 $stateMachine->initialize();
 
-$stateMachine->getDispatcher()->addListener('finite.pre_transition', function(\Finite\Event\TransitionEvent $e) {
+$stateMachine->getDispatcher()->addListener(\Finite\Event\FiniteEvents::PRE_TRANSITION, function(\Finite\Event\TransitionEvent $e) {
     echo 'This is a pre transition', "\n";
 });
+
+$foobar = 42;
+$stateMachine->getDispatcher()->addListener(
+    \Finite\Event\FiniteEvents::POST_TRANSITION,
+    \Finite\Event\Callback\CallbackBuilder::create($stateMachine)
+        ->setCallable(function () use ($foobar) {
+            echo "\$foobar is ${foobar} and this is a post transition\n";
+        })
+        ->getCallback()
+);
 
 $stateMachine->apply('propose');
 $stateMachine->apply('reject');

--- a/src/Finite/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtension.php
+++ b/src/Finite/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtension.php
@@ -31,7 +31,7 @@ class FiniteFiniteExtension extends Extension
             $stateMachineConfig = $this->removeDisabledCallbacks($stateMachineConfig);
 
             $definition = clone $container->getDefinition('finite.array_loader');
-            $definition->addArgument($stateMachineConfig);
+            $definition->replaceArgument(0, $stateMachineConfig);
             $definition->addTag('finite.loader');
 
             // setLazy method wasn't available before 2.3, FiniteBundle requirement is ~2.1

--- a/src/Finite/Bundle/FiniteBundle/Resources/config/services.xml
+++ b/src/Finite/Bundle/FiniteBundle/Resources/config/services.xml
@@ -10,10 +10,20 @@
         <parameter key="finite.factory.class">Finite\Factory\SymfonyDependencyInjectionFactory</parameter>
         <parameter key="finite.context.class">Finite\Context</parameter>
         <parameter key="finite.twig_extension.class">Finite\Extension\Twig\FiniteExtension</parameter>
+        <parameter key="finite.callback.handler.class">Finite\Event\CallbackHandler</parameter>
+        <parameter key="finite.callback.builder.factory.class">Finite\Event\Callback\CallbackBuilderFactory</parameter>
     </parameters>
 
     <services>
-        <service id="finite.array_loader" class="%finite.array_loader.class%" public="false" />
+        <service id="finite.callback.handler" class="%finite.callback.handler.class%">
+            <argument type="service" id="event_dispatcher" />
+        </service>
+        <service id="finite.callback.builder.factory" class="%finite.callback.builder.factory.class%" />
+        <service id="finite.array_loader" class="%finite.array_loader.class%" public="false">
+            <argument type="collection" />
+            <argument type="service" id="finite.callback.handler" />
+            <argument type="service" id="finite.callback.builder.factory" />
+        </service>
         <service id="finite.state_machine" class="%finite.state_machine.class%" scope="prototype">
             <call method="setDispatcher">
                 <argument type="service" id="event_dispatcher" />

--- a/src/Finite/Event/Callback/Callback.php
+++ b/src/Finite/Event/Callback/Callback.php
@@ -42,18 +42,18 @@ class Callback implements CallbackInterface
     /**
      * {@inheritDoc}
      */
-    public function call($object, TransitionEvent $event)
-    {
-        return call_user_func($this->callable, $object, $event);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     public function __invoke(TransitionEvent $event)
     {
         if ($this->specification->isSatisfiedBy($event)) {
             $this->call($event->getStateMachine()->getObject(), $event);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function call($object, TransitionEvent $event)
+    {
+        return call_user_func($this->callable, $object, $event);
     }
 }

--- a/src/Finite/Event/Callback/Callback.php
+++ b/src/Finite/Event/Callback/Callback.php
@@ -32,6 +32,14 @@ class Callback implements CallbackInterface
     }
 
     /**
+     * @return CallbackSpecificationInterface
+     */
+    public function getSpecification()
+    {
+        return $this->specification;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function call($object, TransitionEvent $event)

--- a/src/Finite/Event/Callback/Callback.php
+++ b/src/Finite/Event/Callback/Callback.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Finite\Event\Callback;
+
+use Finite\Event\TransitionEvent;
+
+/**
+ *
+ *
+ * @author Yohan Giarelli <yohan@frequence-web.fr>
+ */
+class Callback implements CallbackInterface
+{
+    /**
+     * @var CallbackSpecificationInterface
+     */
+    private $specification;
+
+    /**
+     * @var callable
+     */
+    private $callable;
+
+    /**
+     * @param CallbackSpecificationInterface $callbackSpecification
+     * @param callable                       $callable
+     */
+    public function __construct(CallbackSpecificationInterface $callbackSpecification, $callable)
+    {
+        $this->specification = $callbackSpecification;
+        $this->callable      = $callable;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function call($object, TransitionEvent $event)
+    {
+        return call_user_func($this->callable, $object, $event);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __invoke(TransitionEvent $event)
+    {
+        if ($this->specification->isSatisfiedBy($event)) {
+            $this->call($event->getStateMachine()->getObject(), $event);
+        }
+    }
+}

--- a/src/Finite/Event/Callback/CallbackBuilder.php
+++ b/src/Finite/Event/Callback/CallbackBuilder.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Finite\Event\Callback;
+
+use Finite\StateMachine\StateMachineInterface;
+
+/**
+ * Builds a Callback instance
+ *
+ * @author Yohan Giarelli <yohan@frequence-web.fr>
+ */
+class CallbackBuilder
+{
+    /**
+     * @var StateMachineInterface
+     */
+    private $stateMachine;
+
+    /**
+     * @var array
+     */
+    private $from;
+
+    /**
+     * @var array
+     */
+    private $to;
+
+    /**
+     * @var array
+     */
+    private $on;
+
+    /**
+     * @var callable
+     */
+    private $callable;
+
+    /**
+     * @param StateMachineInterface $sm
+     * @param array                 $from
+     * @param array                 $to
+     * @param array                 $on
+     * @param callable              $callable
+     */
+    public function __construct(StateMachineInterface $sm, array $from = array(), array $to = array(), array $on = array(), $callable = null)
+    {
+        $this->stateMachine = $sm;
+        $this->from         = $from;
+        $this->to           = $to;
+        $this->on           = $on;
+        $this->callable     = $callable;
+    }
+
+    /**
+     * @param array $from
+     *
+     * @return CallbackBuilder
+     */
+    public function setFrom(array $from)
+    {
+        $this->from = $from;
+
+        return $this;
+    }
+
+    /**
+     * @param array $to
+     *
+     * @return CallbackBuilder
+     */
+    public function setTo(array $to)
+    {
+        $this->to = $to;
+
+        return $this;
+    }
+
+    /**
+     * @param array $on
+     *
+     * @return CallbackBuilder
+     */
+    public function setOn(array $on)
+    {
+        $this->on = $on;
+
+        return $this;
+    }
+
+    /**
+     * @param callable $callable
+     *
+     * @return CallbackBuilder
+     */
+    public function setCallable($callable)
+    {
+        $this->callable = $callable;
+
+        return $this;
+    }
+
+    /**
+     * @param string $from
+     *
+     * @return CallbackBuilder
+     */
+    public function addFrom($from)
+    {
+        $this->from[] = $from;
+
+        return $this;
+    }
+
+    /**
+     * @param string $to
+     *
+     * @return CallbackBuilder
+     */
+    public function addTo($to)
+    {
+        $this->to[] = $to;
+
+        return $this;
+    }
+
+    /**
+     * @param string $on
+     *
+     * @return CallbackBuilder
+     */
+    public function addOn($on)
+    {
+        $this->from[] = $on;
+
+        return $this;
+    }
+
+    /**
+     * @return Callback
+     */
+    public function getCallback()
+    {
+        return new Callback(
+            new CallbackSpecification($this->stateMachine, $this->from, $this->to, $this->on),
+            $this->callable
+        );
+    }
+
+    /**
+     * @param StateMachineInterface $sm
+     * @param array                 $from
+     * @param array                 $to
+     * @param array                 $on
+     * @param callable              $callable
+     *
+     * @return CallbackBuilder
+     */
+    public static function create(StateMachineInterface $sm, array $from = array(), array $to = array(), array $on = array(), $callable = null)
+    {
+        return new self($sm, $from, $to, $on, $callable);
+    }
+}

--- a/src/Finite/Event/Callback/CallbackBuilderFactory.php
+++ b/src/Finite/Event/Callback/CallbackBuilderFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Finite\Event\Callback;
+
+use Finite\StateMachine\StateMachineInterface;
+
+/**
+ * Concrete implementation of CallbackBuilder factory
+ *
+ * @author Yohan Giarelli <yohan@frequence-web.fr>
+ */
+class CallbackBuilderFactory implements CallbackBuilderFactoryInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function createBuilder(StateMachineInterface $stateMachine)
+    {
+        return CallbackBuilder::create($stateMachine);
+    }
+}

--- a/src/Finite/Event/Callback/CallbackBuilderFactoryInterface.php
+++ b/src/Finite/Event/Callback/CallbackBuilderFactoryInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Finite\Event\Callback;
+
+use Finite\StateMachine\StateMachineInterface;
+
+/**
+ * Base interface for CallbackBuilder factories
+ *
+ * @author Yohan Giarelli <yohan@frequence-web.fr>
+ */
+interface CallbackBuilderFactoryInterface
+{
+    /**
+     * @param StateMachineInterface $stateMachine
+     *
+     * @return mixed
+     */
+    public function createBuilder(StateMachineInterface $stateMachine);
+}

--- a/src/Finite/Event/Callback/CallbackInterface.php
+++ b/src/Finite/Event/Callback/CallbackInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Finite\Event\Callback;
+
+use Finite\Event\TransitionEvent;
+
+/**
+ * Base interface for callbacks
+ *
+ * @author Yohan Giarelli <yohan@frequence-web.fr>
+ */
+interface CallbackInterface
+{
+    /**
+     * @param object          $object
+     * @param TransitionEvent $event
+     */
+    public function call($object, TransitionEvent $event);
+
+    /**
+     * @param TransitionEvent $event
+     */
+    public function __invoke(TransitionEvent $event);
+}

--- a/src/Finite/Event/Callback/CallbackInterface.php
+++ b/src/Finite/Event/Callback/CallbackInterface.php
@@ -12,12 +12,6 @@ use Finite\Event\TransitionEvent;
 interface CallbackInterface
 {
     /**
-     * @param object          $object
-     * @param TransitionEvent $event
-     */
-    public function call($object, TransitionEvent $event);
-
-    /**
      * @param TransitionEvent $event
      */
     public function __invoke(TransitionEvent $event);

--- a/src/Finite/Event/Callback/CallbackSpecification.php
+++ b/src/Finite/Event/Callback/CallbackSpecification.php
@@ -58,9 +58,9 @@ class CallbackSpecification implements CallbackSpecificationInterface
     {
         return
             $event->getStateMachine() === $this->stateMachine &&
-            $this->supportClause('from', $event->getInitialState()->getName()) &&
-            $this->supportClause('to', $event->getTransition()->getState()) &&
-            $this->supportClause('on', $event->getTransition()->getName());
+            $this->supportsClause('from', $event->getInitialState()->getName()) &&
+            $this->supportsClause('to', $event->getTransition()->getState()) &&
+            $this->supportsClause('on', $event->getTransition()->getName());
     }
 
     /**
@@ -69,7 +69,7 @@ class CallbackSpecification implements CallbackSpecificationInterface
      *
      * @return bool
      */
-    private function supportClause($clause, $property)
+    private function supportsClause($clause, $property)
     {
         $excludedClause = 'excluded_' . $clause;
 

--- a/src/Finite/Event/Callback/CallbackSpecification.php
+++ b/src/Finite/Event/Callback/CallbackSpecification.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Finite\Event\Callback;
+
+use Finite\Event\TransitionEvent;
+
+/**
+ * Concrete implementation of CallbackSpecification
+ *
+ * @author Yohan Giarelli <yohan@frequence-web.fr>
+ */
+class CallbackSpecification implements CallbackSpecificationInterface
+{
+    /**
+     * @var array
+     */
+    private $specs = array();
+
+    /**
+     * @var callable
+     */
+    private $callback;
+
+    /**
+     * @param array    $from
+     * @param array    $to
+     * @param array    $on
+     * @param callable $callback
+     */
+    public function __construct(array $from, array $to, array $on, $callback)
+    {
+        $isExclusion = function ($str) {
+            return 0 === strpos($str, '-');
+        };
+        $removeDash  = function ($str) {
+            return substr($str, 1);
+        };
+
+        foreach (array('from', 'to', 'on') as $clause) {
+            $excludedClause = 'excluded_' . $clause;
+
+            $this->specs[$excludedClause] = array_filter(${$clause}, $isExclusion);
+            $this->specs[$clause]         = array_diff(${$clause}, $this->specs[$excludedClause]);
+            $this->specs[$excludedClause] = array_map($removeDash, $this->specs[$excludedClause]);
+        }
+
+        $this->callback = $callback;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports(TransitionEvent $event)
+    {
+        return
+            $this->supportClause('from', $event->getInitialState()) &&
+            $this->supportClause('to', $event->getTransition()->getState()) &&
+            $this->supportClause('on', $event->getTransition()->getName());
+    }
+
+    /**
+     * @param string $clause
+     * @param string $property
+     *
+     * @return bool
+     */
+    private function supportClause($clause, $property)
+    {
+        $excludedClause = 'excluded_' . $clause;
+
+        return
+            (0 === count($this->specs[$clause]) || in_array($property, $this->specs[$clause])) &&
+            (0 === count($this->specs[$excludedClause]) || !in_array($property, $this->specs[$excludedClause]));
+    }
+}

--- a/src/Finite/Event/Callback/CallbackSpecification.php
+++ b/src/Finite/Event/Callback/CallbackSpecification.php
@@ -2,6 +2,7 @@
 
 namespace Finite\Event\Callback;
 
+use Finite\Event\CallbackHandler;
 use Finite\Event\TransitionEvent;
 
 /**
@@ -42,6 +43,12 @@ class CallbackSpecification implements CallbackSpecificationInterface
             $this->specs[$excludedClause] = array_filter(${$clause}, $isExclusion);
             $this->specs[$clause]         = array_diff(${$clause}, $this->specs[$excludedClause]);
             $this->specs[$excludedClause] = array_map($removeDash, $this->specs[$excludedClause]);
+
+            // For compatibility with old CallbackHandler.
+            // To be removed in 2.0
+            if (in_array(CallbackHandler::ALL, $this->specs[$clause])) {
+                $this->specs[$clause] = array();
+            }
         }
 
         $this->callback = $callback;
@@ -50,12 +57,20 @@ class CallbackSpecification implements CallbackSpecificationInterface
     /**
      * {@inheritDoc}
      */
-    public function supports(TransitionEvent $event)
+    public function isSatisfiedBy(TransitionEvent $event)
     {
         return
             $this->supportClause('from', $event->getInitialState()) &&
             $this->supportClause('to', $event->getTransition()->getState()) &&
             $this->supportClause('on', $event->getTransition()->getName());
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getCallback()
+    {
+        return $this->callback;
     }
 
     /**

--- a/src/Finite/Event/Callback/CallbackSpecification.php
+++ b/src/Finite/Event/Callback/CallbackSpecification.php
@@ -58,7 +58,7 @@ class CallbackSpecification implements CallbackSpecificationInterface
     {
         return
             $event->getStateMachine() === $this->stateMachine &&
-            $this->supportClause('from', $event->getInitialState()) &&
+            $this->supportClause('from', $event->getInitialState()->getName()) &&
             $this->supportClause('to', $event->getTransition()->getState()) &&
             $this->supportClause('on', $event->getTransition()->getName());
     }

--- a/src/Finite/Event/Callback/CallbackSpecificationInterface.php
+++ b/src/Finite/Event/Callback/CallbackSpecificationInterface.php
@@ -19,11 +19,4 @@ interface CallbackSpecificationInterface
      * @return boolean
      */
     public function isSatisfiedBy(TransitionEvent $event);
-
-    /**
-     * Return the callback carried by the specification
-     *
-     * @return callable
-     */
-    public function getCallback();
 }

--- a/src/Finite/Event/Callback/CallbackSpecificationInterface.php
+++ b/src/Finite/Event/Callback/CallbackSpecificationInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Finite\Event\Callback;
+
+use Finite\Event\TransitionEvent;
+
+/**
+ * Base interface for CallbackSpecification
+ *
+ * @author Yohan Giarelli <yohan@frequence-web.fr>
+ */
+interface CallbackSpecificationInterface
+{
+    const ALL = 'all';
+
+    /**
+     * Return if this callback carried by this spec should be called on this event
+     *
+     * @param TransitionEvent $event
+     *
+     * @return boolean
+     */
+    public function supports(TransitionEvent $event);
+}

--- a/src/Finite/Event/Callback/CallbackSpecificationInterface.php
+++ b/src/Finite/Event/Callback/CallbackSpecificationInterface.php
@@ -11,8 +11,6 @@ use Finite\Event\TransitionEvent;
  */
 interface CallbackSpecificationInterface
 {
-    const ALL = 'all';
-
     /**
      * Return if this callback carried by this spec should be called on this event
      *
@@ -20,5 +18,12 @@ interface CallbackSpecificationInterface
      *
      * @return boolean
      */
-    public function supports(TransitionEvent $event);
+    public function isSatisfiedBy(TransitionEvent $event);
+
+    /**
+     * Return the callback carried by the specification
+     *
+     * @return callable
+     */
+    public function getCallback();
 }

--- a/src/Finite/Event/CallbackHandler.php
+++ b/src/Finite/Event/CallbackHandler.php
@@ -95,7 +95,7 @@ class CallbackHandler
      *
      * @return CallbackHandler
      */
-    protected function add($smOrCallback, $event, $callable = null, array $specs = null)
+    protected function add($smOrCallback, $event, $callable = null, array $specs = array())
     {
         if ($smOrCallback instanceof Callback) {
             $this->dispatcher->addListener($event, $smOrCallback);

--- a/src/Finite/Loader/ArrayLoader.php
+++ b/src/Finite/Loader/ArrayLoader.php
@@ -170,7 +170,7 @@ class ArrayLoader implements LoaderInterface
             )
         );
         $toArrayNormalizer = function (Options $options, $value) {
-            return (array)$value;
+            return (array) $value;
         };
         $resolver->setNormalizers(
             array(

--- a/src/Finite/Loader/ArrayLoader.php
+++ b/src/Finite/Loader/ArrayLoader.php
@@ -175,23 +175,16 @@ class ArrayLoader implements LoaderInterface
 
         $resolver->setRequired(array('do'));
 
-        $resolver->setAllowedTypes(
-            array(
-                'on'   => array('string', 'array'),
-                'from' => array('string', 'array'),
-                'to'   => array('string', 'array'),
-            )
-        );
+        $resolver->setAllowedTypes('on',   array('string', 'array'));
+        $resolver->setAllowedTypes('from', array('string', 'array'));
+        $resolver->setAllowedTypes('to',   array('string', 'array'));
+
         $toArrayNormalizer = function (Options $options, $value) {
             return (array) $value;
         };
-        $resolver->setNormalizers(
-            array(
-                'on'   => $toArrayNormalizer,
-                'from' => $toArrayNormalizer,
-                'to'   => $toArrayNormalizer,
-            )
-        );
+        $resolver->setNormalizer('on',  $toArrayNormalizer);
+        $resolver->setNormalizer('from', $toArrayNormalizer);
+        $resolver->setNormalizer('to',   $toArrayNormalizer);
 
         return $resolver;
     }

--- a/tests/Finite/Test/Acceptance/CallbacksTest.php
+++ b/tests/Finite/Test/Acceptance/CallbacksTest.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Finite\Test\Acceptance;
+
+use Finite\Loader\ArrayLoader;
+use Finite\StateMachine\StateMachine;
+
+/**
+ * @author Yohan Giarelli <yohan@frequence-web.fr>
+ */
+class CallbacksTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var StateMachine
+     */
+    protected $stateMachine;
+
+    /**
+     * @var StateMachine
+     */
+    protected $alternativeStateMachine;
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $callbacksMock;
+
+    protected $object;
+
+    protected $alternativeObject;
+
+    protected function setUp()
+    {
+        $this->object              = new \stdClass;
+        $this->object->finiteState = null;
+
+        $this->alternativeObject              = new \stdClass;
+        $this->alternativeObject->finiteState = null;
+
+        $this->stateMachine            = new StateMachine($this->object);
+        $this->alternativeStateMachine = new StateMachine($this->alternativeObject, $this->stateMachine->getDispatcher());
+
+        $this->callbacksMock = $this
+            ->getMockBuilder('\stdClass')
+            ->setMethods(
+                array(
+                    'afterItWasProposed',
+                    'afterItWasProposedOrReviewed',
+                    'afterItWasAnythingButProposed',
+                    'onReview',
+                    'afterItLeavesReviewed'
+                )
+            )
+            ->getMock();
+
+        $states = array(
+            'draft'     => array('type' => 'initial'),
+            'proposed'  => array(),
+            'reviewed'  => array(),
+            'published' => array('type' => 'final'),
+            'declined'  => array('type' => 'final'),
+        );
+
+        $transitions = array(
+            'propose'         => array('from' => 'draft', 'to' => 'proposed'),
+            'return_to_draft' => array('from' => 'proposed', 'to' => 'draft'),
+            'review'          => array('from' => 'proposed', 'to' => 'reviewed'),
+            'publish'         => array('from' => 'reviewed', 'to' => 'published'),
+            'decline'         => array('from' => array('proposed', 'reviewed'), 'to' => 'declined'),
+        );
+
+        $loader = new ArrayLoader(
+            array(
+                'states'      => $states,
+                'transitions' => $transitions,
+                'callbacks'   => array(
+                    'after' => array(
+                        array(
+                            'to' => 'proposed',
+                            'do' => array($this->callbacksMock, 'afterItWasProposed'),
+                        ),
+                        array(
+                            'to' => array('proposed', 'reviewed'),
+                            'do' => array($this->callbacksMock, 'afterItWasProposedOrReviewed'),
+                        ),
+                        array(
+                            'to' => array('-proposed'),
+                            'do' => array($this->callbacksMock, 'afterItWasAnythingButProposed'),
+                        ),
+                        array(
+                            'on' => 'review',
+                            'do' => array($this->callbacksMock, 'onReview'),
+                        ),
+                        array(
+                            'from' => 'reviewed',
+                            'do'   => array($this->callbacksMock, 'afterItLeavesReviewed'),
+                        ),
+                    )
+                )
+            )
+        );
+
+        $loader->load($this->stateMachine);
+        $this->stateMachine->initialize();
+
+        $alternativeLoader = new ArrayLoader(array('states' => $states, 'transitions' => $transitions));
+
+        $alternativeLoader->load($this->alternativeStateMachine);
+        $this->alternativeStateMachine->initialize();
+    }
+
+    public function test()
+    {
+        $this->callbacksMock->expects($this->once())->method('afterItWasProposed');
+        $this->callbacksMock->expects($this->exactly(2))->method('afterItWasProposedOrReviewed');
+        $this->callbacksMock->expects($this->exactly(2))->method('afterItWasAnythingButProposed');
+        $this->callbacksMock->expects($this->once())->method('onReview');
+        $this->callbacksMock->expects($this->once())->method('afterItLeavesReviewed');
+
+        $this->stateMachine->apply('propose');
+        $this->stateMachine->apply('review');
+        $this->stateMachine->apply('publish');
+
+        $this->alternativeStateMachine->apply('propose');
+        $this->alternativeStateMachine->apply('review');
+        $this->alternativeStateMachine->apply('publish');
+    }
+}

--- a/tests/Finite/Test/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtensionTest.php
+++ b/tests/Finite/Test/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtensionTest.php
@@ -38,6 +38,8 @@ class FiniteFiniteExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->container->hasDefinition('finite.loader.workflow1'));
         $this->assertTrue($this->container->hasDefinition('finite.context'));
         $this->assertTrue($this->container->hasDefinition('finite.twig_extension'));
+        $this->assertTrue($this->container->hasDefinition('finite.callback.handler'));
+        $this->assertTrue($this->container->hasDefinition('finite.callback.builder.factory'));
 
         $this->assertTrue($this->container->getDefinition('finite.loader.workflow1')->isLazy());
 

--- a/tests/Finite/Test/Event/Callback/CallbackBuilderFactoryTest.php
+++ b/tests/Finite/Test/Event/Callback/CallbackBuilderFactoryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Finite\Test\Event\Callback;
+
+use Finite\Event\Callback\CallbackBuilderFactory;
+
+/**
+ * @author Yohan Giarelli <yohan@frequence-web.fr>
+ */
+class CallbackBuilderFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    public function testItConstructsCallbackBuilder()
+    {
+        $sm = $this->getMock('Finite\StateMachine\StateMachineInterface');
+
+        $factory = new CallbackBuilderFactory;
+
+        $this->assertInstanceOf('Finite\Event\Callback\CallbackBuilder', $builder = $factory->createBuilder($sm));
+        $this->assertNotSame($builder, $factory->createBuilder($sm));
+    }
+}

--- a/tests/Finite/Test/Event/Callback/CallbackBuilderTest.php
+++ b/tests/Finite/Test/Event/Callback/CallbackBuilderTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Finite\Test\Event\Callback;
+
+use Finite\Event\Callback\CallbackBuilder;
+
+/**
+ * @author Yohan Giarelli <yohan@frequence-web.fr>
+ */
+class CallbackBuilderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testItBuildsCallback()
+    {
+        $stateMachine = $this
+            ->getMockBuilder('Finite\StateMachine\StateMachine')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $callableMock = $this->getMockBuilder('\stdClass')->setMethods(array('call'))->getMock();
+
+        $callback = CallbackBuilder::create($stateMachine, array($callableMock, 'call'))
+            ->setFrom(array('s1'))
+            ->addFrom('s2')
+            ->setTo(array('s2'))
+            ->addTo('s3')
+            ->setOn(array('t12'))
+            ->addOn('t23')
+            ->getCallback();
+
+        $this->assertInstanceOf('Finite\Event\Callback\Callback', $callback);
+        $this->assertInstanceOf('Finite\Event\Callback\CallbackSpecification', $callback->getSpecification());
+    }
+}

--- a/tests/Finite/Test/Event/Callback/CallbackSpecificationTest.php
+++ b/tests/Finite/Test/Event/Callback/CallbackSpecificationTest.php
@@ -19,49 +19,49 @@ class CallbackSpecificationTest extends \PHPUnit_Framework_TestCase
         $this->stateMachine = $this->getMock('Finite\StateMachine\StateMachine');
     }
 
-    public function testItSupportsFrom()
+    public function testItIsSatisfiedByFrom()
     {
         $spec = new CallbackSpecification(array('s1', 's2'), array(), array(), function() {});
 
-        $this->assertTrue($spec->supports($this->getTransitionEvent('s1', 't12', 's2')));
-        $this->assertTrue($spec->supports($this->getTransitionEvent('s2', 't23', 's3')));
-        $this->assertFalse($spec->supports($this->getTransitionEvent('s3', 't34', 's4')));
+        $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
+        $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
+        $this->assertFalse($spec->isSatisfiedBy($this->getTransitionEvent('s3', 't34', 's4')));
 
         $spec = new CallbackSpecification(array('-s3'), array(), array(), function() {});
 
-        $this->assertTrue($spec->supports($this->getTransitionEvent('s1', 't12', 's2')));
-        $this->assertTrue($spec->supports($this->getTransitionEvent('s2', 't23', 's3')));
-        $this->assertFalse($spec->supports($this->getTransitionEvent('s3', 't34', 's4')));
+        $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
+        $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
+        $this->assertFalse($spec->isSatisfiedBy($this->getTransitionEvent('s3', 't34', 's4')));
     }
 
-    public function testItSupportsTo()
+    public function testItIsSatisfiedByTo()
     {
         $spec = new CallbackSpecification(array(), array('s2', 's3'), array(), function() {});
 
-        $this->assertTrue($spec->supports($this->getTransitionEvent('s1', 't12', 's2')));
-        $this->assertTrue($spec->supports($this->getTransitionEvent('s2', 't23', 's3')));
-        $this->assertFalse($spec->supports($this->getTransitionEvent('s3', 't34', 's4')));
+        $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
+        $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
+        $this->assertFalse($spec->isSatisfiedBy($this->getTransitionEvent('s3', 't34', 's4')));
 
         $spec = new CallbackSpecification(array(), array('-s4'), array(), function() {});
 
-        $this->assertTrue($spec->supports($this->getTransitionEvent('s1', 't12', 's2')));
-        $this->assertTrue($spec->supports($this->getTransitionEvent('s2', 't23', 's3')));
-        $this->assertFalse($spec->supports($this->getTransitionEvent('s3', 't34', 's4')));
+        $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
+        $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
+        $this->assertFalse($spec->isSatisfiedBy($this->getTransitionEvent('s3', 't34', 's4')));
     }
 
-    public function testItSupportsOn()
+    public function testItIsSatisfiedByOn()
     {
         $spec = new CallbackSpecification(array(), array(), array('t12', 't23'), function() {});
 
-        $this->assertTrue($spec->supports($this->getTransitionEvent('s1', 't12', 's2')));
-        $this->assertTrue($spec->supports($this->getTransitionEvent('s2', 't23', 's3')));
-        $this->assertFalse($spec->supports($this->getTransitionEvent('s3', 't34', 's4')));
+        $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
+        $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
+        $this->assertFalse($spec->isSatisfiedBy($this->getTransitionEvent('s3', 't34', 's4')));
 
         $spec = new CallbackSpecification(array(), array(), array('-t34'), function() {});
 
-        $this->assertTrue($spec->supports($this->getTransitionEvent('s1', 't12', 's2')));
-        $this->assertTrue($spec->supports($this->getTransitionEvent('s2', 't23', 's3')));
-        $this->assertFalse($spec->supports($this->getTransitionEvent('s3', 't34', 's4')));
+        $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
+        $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
+        $this->assertFalse($spec->isSatisfiedBy($this->getTransitionEvent('s3', 't34', 's4')));
     }
 
     /**

--- a/tests/Finite/Test/Event/Callback/CallbackSpecificationTest.php
+++ b/tests/Finite/Test/Event/Callback/CallbackSpecificationTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Finite\Test\Event\Callback;
+
+use Finite\Event\Callback\CallbackSpecification;
+use Finite\Event\TransitionEvent;
+use Finite\State\State;
+use Finite\Transition\Transition;
+
+/**
+ * @author Yohan Giarelli <yohan@frequence-web.fr>
+ */
+class CallbackSpecificationTest extends \PHPUnit_Framework_TestCase
+{
+    private $stateMachine;
+
+    protected function setUp()
+    {
+        $this->stateMachine = $this->getMock('Finite\StateMachine\StateMachine');
+    }
+
+    public function testItSupportsFrom()
+    {
+        $spec = new CallbackSpecification(array('s1', 's2'), array(), array(), function() {});
+
+        $this->assertTrue($spec->supports($this->getTransitionEvent('s1', 't12', 's2')));
+        $this->assertTrue($spec->supports($this->getTransitionEvent('s2', 't23', 's3')));
+        $this->assertFalse($spec->supports($this->getTransitionEvent('s3', 't34', 's4')));
+
+        $spec = new CallbackSpecification(array('-s3'), array(), array(), function() {});
+
+        $this->assertTrue($spec->supports($this->getTransitionEvent('s1', 't12', 's2')));
+        $this->assertTrue($spec->supports($this->getTransitionEvent('s2', 't23', 's3')));
+        $this->assertFalse($spec->supports($this->getTransitionEvent('s3', 't34', 's4')));
+    }
+
+    public function testItSupportsTo()
+    {
+        $spec = new CallbackSpecification(array(), array('s2', 's3'), array(), function() {});
+
+        $this->assertTrue($spec->supports($this->getTransitionEvent('s1', 't12', 's2')));
+        $this->assertTrue($spec->supports($this->getTransitionEvent('s2', 't23', 's3')));
+        $this->assertFalse($spec->supports($this->getTransitionEvent('s3', 't34', 's4')));
+
+        $spec = new CallbackSpecification(array(), array('-s4'), array(), function() {});
+
+        $this->assertTrue($spec->supports($this->getTransitionEvent('s1', 't12', 's2')));
+        $this->assertTrue($spec->supports($this->getTransitionEvent('s2', 't23', 's3')));
+        $this->assertFalse($spec->supports($this->getTransitionEvent('s3', 't34', 's4')));
+    }
+
+    public function testItSupportsOn()
+    {
+        $spec = new CallbackSpecification(array(), array(), array('t12', 't23'), function() {});
+
+        $this->assertTrue($spec->supports($this->getTransitionEvent('s1', 't12', 's2')));
+        $this->assertTrue($spec->supports($this->getTransitionEvent('s2', 't23', 's3')));
+        $this->assertFalse($spec->supports($this->getTransitionEvent('s3', 't34', 's4')));
+
+        $spec = new CallbackSpecification(array(), array(), array('-t34'), function() {});
+
+        $this->assertTrue($spec->supports($this->getTransitionEvent('s1', 't12', 's2')));
+        $this->assertTrue($spec->supports($this->getTransitionEvent('s2', 't23', 's3')));
+        $this->assertFalse($spec->supports($this->getTransitionEvent('s3', 't34', 's4')));
+    }
+
+    /**
+     * @param string $fromState
+     * @param string $transition
+     * @param string $toState
+     *
+     * @return TransitionEvent
+     */
+    private function getTransitionEvent($fromState, $transition, $toState)
+    {
+        return new TransitionEvent(
+            new State($fromState),
+            new Transition($transition, array($fromState), $toState),
+            $this->stateMachine
+        );
+    }
+}

--- a/tests/Finite/Test/Event/Callback/CallbackSpecificationTest.php
+++ b/tests/Finite/Test/Event/Callback/CallbackSpecificationTest.php
@@ -21,13 +21,13 @@ class CallbackSpecificationTest extends \PHPUnit_Framework_TestCase
 
     public function testItIsSatisfiedByFrom()
     {
-        $spec = new CallbackSpecification(array('s1', 's2'), array(), array(), function() {});
+        $spec = new CallbackSpecification($this->stateMachine, array('s1', 's2'), array(), array());
 
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
         $this->assertFalse($spec->isSatisfiedBy($this->getTransitionEvent('s3', 't34', 's4')));
 
-        $spec = new CallbackSpecification(array('-s3'), array(), array(), function() {});
+        $spec = new CallbackSpecification($this->stateMachine, array('-s3'), array(), array());
 
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
@@ -36,13 +36,13 @@ class CallbackSpecificationTest extends \PHPUnit_Framework_TestCase
 
     public function testItIsSatisfiedByTo()
     {
-        $spec = new CallbackSpecification(array(), array('s2', 's3'), array(), function() {});
+        $spec = new CallbackSpecification($this->stateMachine, array(), array('s2', 's3'), array());
 
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
         $this->assertFalse($spec->isSatisfiedBy($this->getTransitionEvent('s3', 't34', 's4')));
 
-        $spec = new CallbackSpecification(array(), array('-s4'), array(), function() {});
+        $spec = new CallbackSpecification($this->stateMachine, array(), array('-s4'), array());
 
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
@@ -51,13 +51,13 @@ class CallbackSpecificationTest extends \PHPUnit_Framework_TestCase
 
     public function testItIsSatisfiedByOn()
     {
-        $spec = new CallbackSpecification(array(), array(), array('t12', 't23'), function() {});
+        $spec = new CallbackSpecification($this->stateMachine, array(), array(), array('t12', 't23'));
 
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
         $this->assertFalse($spec->isSatisfiedBy($this->getTransitionEvent('s3', 't34', 's4')));
 
-        $spec = new CallbackSpecification(array(), array(), array('-t34'), function() {});
+        $spec = new CallbackSpecification($this->stateMachine, array(), array(), array('-t34'));
 
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));

--- a/tests/Finite/Test/Event/Callback/CallbackTest.php
+++ b/tests/Finite/Test/Event/Callback/CallbackTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Finite\Test\Event\Callback;
+
+use Finite\Event\Callback\Callback;
+
+/**
+ * @author Yohan Giarelli <yohan@frequence-web.fr>
+ */
+class CallbackTest extends \PHPUnit_Framework_TestCase
+{
+    public function testItCallsCallable()
+    {
+        $spec         = $this->getMockBuilder('Finite\Event\Callback\CallbackSpecification')->disableOriginalConstructor()->getMock();
+        $callableMock = $this->getMockBuilder('\stdClass')->setMethods(array('call'))->getMock();
+        $event        = $this->getMockBuilder('Finite\Event\TransitionEvent')->disableOriginalConstructor()->getMock();
+
+        $callableMock->expects($this->once())->method('call');
+
+        $callback = new Callback($spec, array($callableMock, 'call'));
+        $callback->call(new \stdClass, $event);
+    }
+
+    public function testInvokeWithGoodSpec()
+    {
+        $spec         = $this->getMockBuilder('Finite\Event\Callback\CallbackSpecification')->disableOriginalConstructor()->getMock();
+        $callableMock = $this->getMockBuilder('\stdClass')->setMethods(array('call'))->getMock();
+        $event        = $this->getMockBuilder('Finite\Event\TransitionEvent')->disableOriginalConstructor()->getMock();
+        $stateMachine = $this->getMockBuilder('Finite\StateMachine\StateMachine')->disableOriginalConstructor()->getMock();
+
+        $event->expects($this->once())->method('getStateMachine')->will($this->returnValue($stateMachine));
+        $spec->expects($this->once())->method('isSatisfiedBy')->with($event)->will($this->returnValue(true));
+
+        $callableMock->expects($this->once())->method('call');
+
+        $callback = new Callback($spec, array($callableMock, 'call'));
+        $callback($event);
+    }
+
+    public function testInvokeWithBadSpec()
+    {
+        $spec         = $this->getMockBuilder('Finite\Event\Callback\CallbackSpecification')->disableOriginalConstructor()->getMock();
+        $callableMock = $this->getMockBuilder('\stdClass')->setMethods(array('call'))->getMock();
+        $event        = $this->getMockBuilder('Finite\Event\TransitionEvent')->disableOriginalConstructor()->getMock();
+
+        $spec->expects($this->once())->method('isSatisfiedBy')->with($event)->will($this->returnValue(false));
+        $callableMock->expects($this->never())->method('call');
+
+        $callback = new Callback($spec, array($callableMock, 'call'));
+        $callback($event);
+    }
+}

--- a/tests/Finite/Test/Event/Callback/CallbackTest.php
+++ b/tests/Finite/Test/Event/Callback/CallbackTest.php
@@ -9,18 +9,6 @@ use Finite\Event\Callback\Callback;
  */
 class CallbackTest extends \PHPUnit_Framework_TestCase
 {
-    public function testItCallsCallable()
-    {
-        $spec         = $this->getMockBuilder('Finite\Event\Callback\CallbackSpecification')->disableOriginalConstructor()->getMock();
-        $callableMock = $this->getMockBuilder('\stdClass')->setMethods(array('call'))->getMock();
-        $event        = $this->getMockBuilder('Finite\Event\TransitionEvent')->disableOriginalConstructor()->getMock();
-
-        $callableMock->expects($this->once())->method('call');
-
-        $callback = new Callback($spec, array($callableMock, 'call'));
-        $callback->call(new \stdClass, $event);
-    }
-
     public function testInvokeWithGoodSpec()
     {
         $spec         = $this->getMockBuilder('Finite\Event\Callback\CallbackSpecification')->disableOriginalConstructor()->getMock();

--- a/tests/Finite/Test/Loader/ArrayLoaderTest.php
+++ b/tests/Finite/Test/Loader/ArrayLoaderTest.php
@@ -136,17 +136,17 @@ class ArrayLoaderTest extends \PHPUnit_Framework_TestCase
         $this->callbackHandler
             ->expects($this->at(0))
             ->method('addBefore')
-            ->with($sm, $beforeMiddleize, array('on' => 'middleize'));
+            ->with($this->isInstanceOf('Finite\Event\Callback\Callback'));
 
         $this->callbackHandler
             ->expects($this->at(1))
             ->method('addBefore')
-            ->with($sm, $fromStartToOtherThanMiddle, array('from' => 'start', 'to' => '-middle'));
+            ->with($this->isInstanceOf('Finite\Event\Callback\Callback'));
 
         $this->callbackHandler
             ->expects($this->at(2))
             ->method('addAfter')
-            ->with($sm, $allTimes, array());
+            ->with($this->isInstanceOf('Finite\Event\Callback\Callback'));
 
         $this->object->load($sm);
     }


### PR DESCRIPTION
Here is a draft of the refactoring of the CallbackHandler (#48).

It introduces no BC, but it deprecates the previous usage of `CallbackHandler::add*` methods.

Callbacks are now wrapped in a `Callback`, with a `CallbackSpecification` responsible of the execution, or not, of the callback on transition events.

`Callback` defines an `__invoke` method, and instances are directly registered as event listeners.

The Callback instantiation logic has been moved to a `CallbackBuilder` and to the `ArrayLoader`.

I kept the options resolver, as it's pretty good at cleaning configuration arrays.
