### PR TITLE
Version 1.1 is still in dev, revert docs to 1.0 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Getting started
 ```js
 {
       "require": {
-        "yohang/finite": "~1.1"
+        "yohang/finite": "~1.0"
     }
 }
 ```


### PR DESCRIPTION
Could put the @dev thing in, but I think it's correct to recommend people use the stable branch in the README.md.

RE: https://github.com/yohang/Finite/issues/62