### PR TITLE
Unset "disabled" param in ArrayLoader

### DIFF
--- a/src/Finite/Loader/ArrayLoader.php
+++ b/src/Finite/Loader/ArrayLoader.php
@@ -140,6 +140,7 @@ class ArrayLoader implements LoaderInterface
         foreach ($this->config['callbacks'][$position] as $specs) {
             $callback = $specs['do'];
             unset($specs['do']);
+            unset($specs['disabled']);
 
             $this->callbackHandler->$method($stateMachine, $callback, $specs);
         }


### PR DESCRIPTION
Param "disabled" should be unset before passing specs to CallbackHandler. Otherwise it may cause an error because CallbackHandler's OptionResolver does not set default value for "disabled" param.