### PR TITLE
fix for symfony/options-resolver 2.6+

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,8 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
     ],
     "hash": "e289fcf31666dba8d064c3a0c85919c6",
     "packages": [
@@ -63,17 +64,17 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v2.4.4",
+            "version": "v2.6.4",
             "target-dir": "Symfony/Component/OptionsResolver",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/OptionsResolver.git",
-                "reference": "de261aa6d0e5d21583f5ae7e68f3d95f90bbd771"
+                "reference": "ae68b6c97d26edcdf65eb3c2dd2aee502573e0ec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/OptionsResolver/zipball/de261aa6d0e5d21583f5ae7e68f3d95f90bbd771",
-                "reference": "de261aa6d0e5d21583f5ae7e68f3d95f90bbd771",
+                "url": "https://api.github.com/repos/symfony/OptionsResolver/zipball/ae68b6c97d26edcdf65eb3c2dd2aee502573e0ec",
+                "reference": "ae68b6c97d26edcdf65eb3c2dd2aee502573e0ec",
                 "shasum": ""
             },
             "require": {
@@ -82,7 +83,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -96,14 +97,12 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com",
-                    "homepage": "http://fabien.potencier.org",
-                    "role": "Lead Developer"
-                },
-                {
                     "name": "Symfony Community",
                     "homepage": "http://symfony.com/contributors"
+                },
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
                 }
             ],
             "description": "Symfony OptionsResolver Component",
@@ -113,7 +112,7 @@
                 "configuration",
                 "options"
             ],
-            "time": "2014-04-16 10:34:31"
+            "time": "2015-01-08 13:00:41"
         },
         {
             "name": "symfony/property-access",
@@ -1587,6 +1586,8 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
     "platform": {
         "php": ">=5.3.3"
     },

--- a/src/Finite/Event/CallbackHandler.php
+++ b/src/Finite/Event/CallbackHandler.php
@@ -43,15 +43,11 @@ class CallbackHandler
                 'exclude_to'   => array(),
             )
         );
-        $this->specResolver->setAllowedTypes(
-            array(
-                'on'           => array('string', 'array'),
-                'from'         => array('string', 'array'),
-                'to'           => array('string', 'array'),
-                'exclude_from' => array('string', 'array'),
-                'exclude_to'   => array('string', 'array'),
-            )
-        );
+        $this->specResolver->setAllowedTypes('on', array('string', 'array'));
+        $this->specResolver->setAllowedTypes('from', array('string', 'array'));
+        $this->specResolver->setAllowedTypes('to', array('string', 'array'));
+        $this->specResolver->setAllowedTypes('exclude_from', array('string', 'array'));
+        $this->specResolver->setAllowedTypes('exclude_to', array('string', 'array'));
         $toArrayNormalizer = function (Options $options, $value) {
             return (array) $value;
         };

--- a/src/Finite/Loader/ArrayLoader.php
+++ b/src/Finite/Loader/ArrayLoader.php
@@ -81,15 +81,11 @@ class ArrayLoader implements LoaderInterface
     {
         $resolver = new OptionsResolver;
         $resolver->setDefaults(array('type' => StateInterface::TYPE_NORMAL, 'properties' => array()));
-        $resolver->setAllowedValues(
-            array(
-                'type' => array(
-                    StateInterface::TYPE_INITIAL,
-                    StateInterface::TYPE_NORMAL,
-                    StateInterface::TYPE_FINAL
-                )
-            )
-        );
+        $resolver->setAllowedValues('type', array(
+            StateInterface::TYPE_INITIAL,
+            StateInterface::TYPE_NORMAL,
+            StateInterface::TYPE_FINAL
+        ));
 
         foreach ($this->config['states'] as $state => $config) {
             $config = $resolver->resolve($config);


### PR DESCRIPTION
We had an issue with Finite installing along symfony/options-resolver 2.6+ which caused E_DEPRECATED errors due to new syntax of setAllowedTypes method. This little fix removes the error, it is however optional, because you have 2.4.4 in your composer.lock file (which was somehow ignored in our system). You could add this to prevent problems with update to 2.6+/3.0 of options-resolver or simply ignore this, as manual specification of "symfony/options-resolver": "2.4.4" in our composer.json seemed to do the trick too.

Cheers. 

Related to issue #84.