### PR TITLE
Twig SimpleFunction instead of deprecated Function_Method

### DIFF
--- a/src/Finite/Extension/Twig/FiniteExtension.php
+++ b/src/Finite/Extension/Twig/FiniteExtension.php
@@ -30,11 +30,11 @@ class FiniteExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'finite_state'       => new \Twig_Function_Method($this, 'getFiniteState'),
-            'finite_transitions' => new \Twig_Function_Method($this, 'getFiniteTransitions'),
-            'finite_properties'  => new \Twig_Function_Method($this, 'getFiniteProperties'),
-            'finite_has'         => new \Twig_Function_Method($this, 'hasFiniteProperty'),
-            'finite_can'         => new \Twig_Function_Method($this, 'canFiniteTransition'),
+            new \Twig_SimpleFunction('finite_state', [$this, 'getFiniteState']),
+            new \Twig_SimpleFunction('finite_transitions', [$this, 'getFiniteTransitions']),
+            new \Twig_SimpleFunction('finite_properties', [$this, 'getFiniteProperties']),
+            new \Twig_SimpleFunction('finite_has', [$this, 'hasFiniteProperty']),
+            new \Twig_SimpleFunction('finite_can', [$this, 'canFiniteTransition']),
         );
     }
 

--- a/src/Finite/Extension/Twig/FiniteExtension.php
+++ b/src/Finite/Extension/Twig/FiniteExtension.php
@@ -30,11 +30,11 @@ class FiniteExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('finite_state', [$this, 'getFiniteState']),
-            new \Twig_SimpleFunction('finite_transitions', [$this, 'getFiniteTransitions']),
-            new \Twig_SimpleFunction('finite_properties', [$this, 'getFiniteProperties']),
-            new \Twig_SimpleFunction('finite_has', [$this, 'hasFiniteProperty']),
-            new \Twig_SimpleFunction('finite_can', [$this, 'canFiniteTransition']),
+            new \Twig_SimpleFunction('finite_state', array($this, 'getFiniteState')),
+            new \Twig_SimpleFunction('finite_transitions', array($this, 'getFiniteTransitions')),
+            new \Twig_SimpleFunction('finite_properties', array($this, 'getFiniteProperties')),
+            new \Twig_SimpleFunction('finite_has', array($this, 'hasFiniteProperty')),
+            new \Twig_SimpleFunction('finite_can', array($this, 'canFiniteTransition')),
         );
     }
 


### PR DESCRIPTION
The purpose is to update the deprecated twig method Twig_Function_Method to the latest Twig_SimpleFunction method