### PR TITLE
Fix install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Getting started
 }
 ```
 
+or 
+
+```
+composer require yohang/finite
+```
+
 ### Define your Stateful Object
 Your stateful object just need to implement the `StatefulInterface` Interface.
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Getting started
 ```js
 {
       "require": {
-        "yohang/finite": "~1.1"
+        "yohang/finite": "^1.0"
     }
 }
 ```


### PR DESCRIPTION
Hi, 

I noticed the install instruction indicates a 1.1 version, where there are only 1.0.x release. I updated the documentation accordingly and added more general composer install instructions.