### PR TITLE
Use graph in events

### DIFF
--- a/src/Finite/StateMachine/StateMachine.php
+++ b/src/Finite/StateMachine/StateMachine.php
@@ -132,6 +132,9 @@ class StateMachine implements StateMachineInterface
 
         $this->dispatcher->dispatch(FiniteEvents::PRE_TRANSITION, $event);
         $this->dispatcher->dispatch(FiniteEvents::PRE_TRANSITION . '.' . $transitionName, $event);
+        if (null !== $this->getGraph()) {
+            $this->dispatcher->dispatch(FiniteEvents::PRE_TRANSITION . '.' . $this->getGraph() . '.' . $transition->getName(), $event);
+        }
 
         $returnValue = $transition->process($this);
         $this->stateAccessor->setState($this->object, $transition->getState());
@@ -139,6 +142,9 @@ class StateMachine implements StateMachineInterface
 
         $this->dispatcher->dispatch(FiniteEvents::POST_TRANSITION, $event);
         $this->dispatcher->dispatch(FiniteEvents::POST_TRANSITION . '.' . $transitionName, $event);
+        if (null !== $this->getGraph()) {
+            $this->dispatcher->dispatch(FiniteEvents::POST_TRANSITION . '.' . $this->getGraph() . '.' . $transition->getName(), $event);
+        }
 
         return $returnValue;
     }
@@ -161,6 +167,9 @@ class StateMachine implements StateMachineInterface
         $event = new TransitionEvent($this->getCurrentState(), $transition, $this);
         $this->dispatcher->dispatch(FiniteEvents::TEST_TRANSITION, $event);
         $this->dispatcher->dispatch(FiniteEvents::TEST_TRANSITION . '.' . $transition->getName(), $event);
+        if (null !== $this->getGraph()) {
+            $this->dispatcher->dispatch(FiniteEvents::TEST_TRANSITION . '.' . $this->getGraph() . '.' . $transition->getName(), $event);
+        }
 
         return !$event->isRejected();
     }

--- a/tests/Finite/Test/StateMachine/StateMachineTest.php
+++ b/tests/Finite/Test/StateMachine/StateMachineTest.php
@@ -174,4 +174,63 @@ class StateMachineTest extends StateMachineTestCase
 
         $this->assertInstanceOf('Finite\State\State', $this->object->getState($state));
     }
+
+    /**
+     * Test events with a named statemachine
+     */
+    public function testApplyWithGraph()
+    {
+
+        $this->dispatcher
+            ->expects($this->at(1))
+            ->method('dispatch')
+            ->with('finite.test_transition', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+
+        $this->dispatcher
+            ->expects($this->at(2))
+            ->method('dispatch')
+            ->with('finite.test_transition.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+
+        $this->dispatcher
+            ->expects($this->at(3))
+            ->method('dispatch')
+            ->with('finite.test_transition.foo.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+
+        $this->dispatcher
+            ->expects($this->at(4))
+            ->method('dispatch')
+            ->with('finite.pre_transition', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+
+        $this->dispatcher
+            ->expects($this->at(5))
+            ->method('dispatch')
+            ->with('finite.pre_transition.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+
+        $this->dispatcher
+            ->expects($this->at(6))
+            ->method('dispatch')
+            ->with('finite.pre_transition.foo.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+
+        $this->dispatcher
+            ->expects($this->at(7))
+            ->method('dispatch')
+            ->with('finite.post_transition', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+
+        $this->dispatcher
+            ->expects($this->at(8))
+            ->method('dispatch')
+            ->with('finite.post_transition.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+
+        $this->dispatcher
+            ->expects($this->at(9))
+            ->method('dispatch')
+            ->with('finite.post_transition.foo.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+
+        $this->object->setGraph('foo');
+
+        $this->initialize();
+        $this->object->apply('t23');
+        $this->assertSame('s3', $this->object->getCurrentState()->getName());
+    }
+
 }


### PR DESCRIPTION
I often use the same transition names for different state machines. This makes it hard to organize and use events because different transitions result in the same events. I've added an event including the graph name to allow separating this.