### PR TITLE
Added compatibility with Symfony 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,16 +18,16 @@
     ],
     "require": {
         "php":                      ">=5.3.9",
-        "symfony/options-resolver": "~2.6",
-        "symfony/event-dispatcher": "~2.6",
-        "symfony/property-access":  "~2.6"
+        "symfony/options-resolver": "~2.6|~3.0",
+        "symfony/event-dispatcher": "~2.6|~3.0",
+        "symfony/property-access":  "~2.6|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit":              "~4.0",
         "pimple/pimple":                "~1.0",
-        "symfony/dependency-injection": "~2.6",
-        "symfony/framework-bundle":     "~2.6",
-        "symfony/security":             "~2.6",
+        "symfony/dependency-injection": "~2.6|~3.0",
+        "symfony/framework-bundle":     "~2.6|~3.0",
+        "symfony/security":             "~2.6|~3.0",
         "twig/twig":                    "~1.13"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,17 @@
     ],
     "require": {
         "php":                      ">=5.3.9",
-        "symfony/options-resolver": "~2.6|~3.0",
-        "symfony/event-dispatcher": "~2.6|~3.0",
-        "symfony/property-access":  "~2.6|~3.0"
+        "symfony/options-resolver": "^2.6|^3.0",
+        "symfony/event-dispatcher": "^2.6|^3.0",
+        "symfony/property-access":  "^2.6|^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit":              "~4.0",
-        "pimple/pimple":                "~1.0",
-        "symfony/dependency-injection": "~2.6|~3.0",
-        "symfony/framework-bundle":     "~2.6|~3.0",
-        "symfony/security":             "~2.6|~3.0",
-        "twig/twig":                    "~1.13"
+        "phpunit/phpunit":              "^4.0",
+        "pimple/pimple":                "^1.0",
+        "symfony/dependency-injection": "^2.6|^3.0",
+        "symfony/framework-bundle":     "^2.6|^3.0",
+        "symfony/security":             "^2.6|^3.0",
+        "twig/twig":                    "^1.13"
     },
     "suggest": {
         "pimple/pimple":    "Needed for use with PimpleFactory",

--- a/src/Finite/Bundle/FiniteBundle/Resources/config/services.xml
+++ b/src/Finite/Bundle/FiniteBundle/Resources/config/services.xml
@@ -24,7 +24,7 @@
             <argument type="service" id="finite.callback.handler" />
             <argument type="service" id="finite.callback.builder.factory" />
         </service>
-        <service id="finite.state_machine" class="%finite.state_machine.class%" scope="prototype">
+        <service id="finite.state_machine" class="%finite.state_machine.class%" shared="false">
             <call method="setDispatcher">
                 <argument type="service" id="event_dispatcher" />
             </call>

--- a/src/Finite/StateMachine/SecurityAwareStateMachine.php
+++ b/src/Finite/StateMachine/SecurityAwareStateMachine.php
@@ -3,6 +3,7 @@
 namespace Finite\StateMachine;
 
 use Finite\Transition\TransitionInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
@@ -16,16 +17,16 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
 class SecurityAwareStateMachine extends StateMachine
 {
     /**
-     * @var SecurityContextInterface
+     * @var AuthorizationCheckerInterface
      */
-    protected $securityContext;
+    protected $authorizationChecker;
 
     /**
-     * @param SecurityContextInterface $securityContext
+     * @param AuthorizationCheckerInterface $authorizationChecker
      */
-    public function setSecurityContext(SecurityContextInterface $securityContext)
+    public function setSecurityContext(AuthorizationCheckerInterface $authorizationChecker)
     {
-        $this->securityContext = $securityContext;
+        $this->authorizationChecker = $authorizationChecker;
     }
 
     /**
@@ -35,7 +36,7 @@ class SecurityAwareStateMachine extends StateMachine
     {
         $transition = $transition instanceof TransitionInterface ? $transition : $this->getTransition($transition);
 
-        if (!$this->securityContext->isGranted($transition->getName(), $this->getObject())) {
+        if (!$this->authorizationChecker->isGranted($transition->getName(), $this->getObject())) {
             return false;
         }
 

--- a/tests/Finite/Test/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtensionTest.php
+++ b/tests/Finite/Test/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtensionTest.php
@@ -33,7 +33,7 @@ class FiniteFiniteExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertTrue($this->container->has('finite.factory'));
         $this->assertTrue($this->container->has('finite.state_machine'));
-        $this->assertSame('prototype', $this->container->getDefinition('finite.state_machine')->getScope());
+        $this->assertFalse($this->container->getDefinition('finite.state_machine')->isShared());
         $this->assertFalse($this->container->hasDefinition('finite.array_loader'));
         $this->assertTrue($this->container->hasDefinition('finite.loader.workflow1'));
         $this->assertTrue($this->container->hasDefinition('finite.context'));

--- a/tests/Finite/Test/Factory/SymfonyDependencyInjectionFactoryTest.php
+++ b/tests/Finite/Test/Factory/SymfonyDependencyInjectionFactoryTest.php
@@ -22,7 +22,7 @@ class SymfonyDependencyInjectionFactoryTest extends \PHPUnit_Framework_TestCase
         $container = new ContainerBuilder;
         $container
             ->register('state_machine', 'Finite\StateMachine\StateMachine')
-            ->setScope('prototype')
+            ->setShared(false)
             ->setArguments(array(null, null, $this->accessor))
             ->addMethodCall('addTransition', array('t12', 's1', 's2'))
             ->addMethodCall('addTransition', array('t23', 's2', 's3'));
@@ -47,7 +47,7 @@ class SymfonyDependencyInjectionFactoryTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Finite\Exception\FactoryException
+     * @expectedException \Finite\Exception\FactoryException
      */
     public function testNoService()
     {

--- a/tests/Finite/Test/StateMachine/SecurityAwareStateMachineTest.php
+++ b/tests/Finite/Test/StateMachine/SecurityAwareStateMachineTest.php
@@ -29,7 +29,7 @@ class SecurityAwareStateMachineTest extends \PHPUnit_Framework_TestCase
 
     public function testCan()
     {
-        $securityMock = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $securityMock = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
         $this->object->setSecurityContext($securityMock);
 
         $that     = $this;


### PR DESCRIPTION
As Symfony 3 was released yesterday, I updated Finite dependencies to be compatible.

Symfony 3 components will be used when php >= 5.5 is installed.