### PR TITLE
Fixing OptionsResolver with field disabled in callbacks

### DIFF
--- a/src/Finite/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtension.php
+++ b/src/Finite/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtension.php
@@ -73,6 +73,7 @@ class FiniteFiniteExtension extends Extension
                 if ($callback['disabled']) {
                     unset($config['callbacks'][$position][$i]);
                 }
+                unset($config['callbacks'][$position][$i]['disabled']);
             }
         }
 

--- a/tests/Finite/Test/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtensionTest.php
+++ b/tests/Finite/Test/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtensionTest.php
@@ -86,10 +86,10 @@ class FiniteFiniteExtensionTest extends \PHPUnit_Framework_TestCase
             ),
             'callbacks'     => array(
                 'before' => array(
-                    'callback1' => array('on' => '1_to_2', 'do' => array('@my.listener.service', 'on1To2'), 'disabled' => false)
+                    'callback1' => array('on' => '1_to_2', 'do' => array('@my.listener.service', 'on1To2'))
                 ),
                 'after'  => array(
-                    'callback2' => array('from' => '-state3', 'to' => array('state2', 'state3'), 'do' => array('@my.listener.service', 'on1To2'), 'disabled' => false)
+                    'callback2' => array('from' => '-state3', 'to' => array('state2', 'state3'), 'do' => array('@my.listener.service', 'on1To2'))
                 )
             )
         );


### PR DESCRIPTION
not expected by ArrayLoader, just remove in removeDisabledCallbacks function because not need it anymore after cleanup 