### PR TITLE
Created ContextInterface

### DIFF
--- a/src/Finite/Context.php
+++ b/src/Finite/Context.php
@@ -3,7 +3,6 @@
 namespace Finite;
 
 use Finite\Factory\FactoryInterface;
-use Finite\StateMachine\StateMachine;
 
 /**
  * The Finite context.
@@ -11,7 +10,7 @@ use Finite\StateMachine\StateMachine;
  *
  * @author Yohan Giarelli <yohan@frequence-web.fr>
  */
-class Context
+class Context implements ContextInterface
 {
     /**
      * @var FactoryInterface
@@ -27,10 +26,7 @@ class Context
     }
 
     /**
-     * @param object $object
-     * @param string $graph
-     *
-     * @return string
+     * {@inheritdoc}
      */
     public function getState($object, $graph = 'default')
     {
@@ -38,11 +34,7 @@ class Context
     }
 
     /**
-     * @param object $object
-     * @param string $graph
-     * @param bool   $asObject
-     *
-     * @return array<string>
+     * {@inheritdoc}
      */
     public function getTransitions($object, $graph = 'default', $asObject = false)
     {
@@ -61,10 +53,7 @@ class Context
     }
 
     /**
-     * @param object $object
-     * @param string $graph
-     *
-     * @return array<string>
+     * {@inheritdoc}
      */
     public function getProperties($object, $graph = 'default')
     {
@@ -72,11 +61,7 @@ class Context
     }
 
     /**
-     * @param object $object
-     * @param string $property
-     * @param string $graph
-     *
-     * @return bool
+     * {@inheritdoc}
      */
     public function hasProperty($object, $property, $graph = 'default')
     {
@@ -84,10 +69,7 @@ class Context
     }
 
     /**
-     * @param object $object
-     * @param string $graph
-     *
-     * @return StateMachine
+     * {@inheritdoc}
      */
     public function getStateMachine($object, $graph = 'default')
     {

--- a/src/Finite/ContextInterface.php
+++ b/src/Finite/ContextInterface.php
@@ -53,3 +53,4 @@ interface ContextInterface
      */
     public function getStateMachine($object, $graph = 'default');
 }
+

--- a/src/Finite/ContextInterface.php
+++ b/src/Finite/ContextInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Finite;
+
+use Finite\StateMachine\StateMachineInterface;
+
+/**
+ * Interface that all class that have properties must implements
+ *
+ * @author Luis Henrique Mulinari <luis.mulinari@gmail.com>
+ */
+interface ContextInterface
+{
+    /**
+     * @param object $object
+     * @param string $graph
+     *
+     * @return string
+     */
+    public function getState($object, $graph = 'default');
+
+    /**
+     * @param object $object
+     * @param string $graph
+     * @param bool   $asObject
+     *
+     * @return array<string>
+     */
+    public function getTransitions($object, $graph = 'default', $asObject = false);
+
+    /**
+     * @param object $object
+     * @param string $graph
+     *
+     * @return array<string>
+     */
+    public function getProperties($object, $graph = 'default');
+
+    /**
+     * @param object $object
+     * @param string $property
+     * @param string $graph
+     *
+     * @return bool
+     */
+    public function hasProperty($object, $property, $graph = 'default');
+
+    /**
+     * @param object $object
+     * @param string $graph
+     *
+     * @return StateMachineInterface
+     */
+    public function getStateMachine($object, $graph = 'default');
+}

--- a/src/Finite/ContextInterface.php
+++ b/src/Finite/ContextInterface.php
@@ -5,7 +5,7 @@ namespace Finite;
 use Finite\StateMachine\StateMachineInterface;
 
 /**
- * Interface that all class that have properties must implements
+ * Interface that represents the contract between context
  *
  * @author Luis Henrique Mulinari <luis.mulinari@gmail.com>
  */

--- a/src/Finite/Extension/Twig/FiniteExtension.php
+++ b/src/Finite/Extension/Twig/FiniteExtension.php
@@ -2,7 +2,7 @@
 
 namespace Finite\Extension\Twig;
 
-use Finite\Context;
+use Finite\ContextInterface;
 
 /**
  * The Finite Twig extension.
@@ -12,14 +12,14 @@ use Finite\Context;
 class FiniteExtension extends \Twig_Extension
 {
     /**
-     * @var Context
+     * @var ContextInterface
      */
     protected $context;
 
     /**
-     * @param Context $context
+     * @param ContextInterface $context
      */
-    public function __construct(Context $context)
+    public function __construct(ContextInterface $context)
     {
         $this->context = $context;
     }


### PR DESCRIPTION
Created ContextInterface to facilitate the "override" process.

I had a case when I needed to use "custom" Context because my "Finite twig extensions" should have other behavior. OK, I can extend the Context and use this, but in my specific case I don't need the Factory on constructor, for example.

I believe that with a Interface, this process will be more easy.
