### PR TITLE
ArrayLoader should respect state accessor

### DIFF
--- a/src/Finite/Loader/ArrayLoader.php
+++ b/src/Finite/Loader/ArrayLoader.php
@@ -69,7 +69,10 @@ class ArrayLoader implements LoaderInterface
             $this->callbackBuilderFactory = new CallbackBuilderFactory();
         }
 
-        $stateMachine->setStateAccessor(new PropertyPathStateAccessor($this->config['property_path']));
+        if (!$stateMachine->hasStateAccessor()) {
+            $stateMachine->setStateAccessor(new PropertyPathStateAccessor($this->config['property_path']));
+        }
+
         $stateMachine->setGraph($this->config['graph']);
 
         $this->loadStates($stateMachine);

--- a/src/Finite/StateMachine/StateMachine.php
+++ b/src/Finite/StateMachine/StateMachine.php
@@ -339,6 +339,14 @@ class StateMachine implements StateMachineInterface
     /**
      * {@inheritdoc}
      */
+    public function hasStateAccessor()
+    {
+        return null !== $this->stateAccessor;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setGraph($graph)
     {
         $this->graph = $graph;

--- a/src/Finite/StateMachine/StateMachineInterface.php
+++ b/src/Finite/StateMachine/StateMachineInterface.php
@@ -112,6 +112,11 @@ interface StateMachineInterface
     public function setStateAccessor(StateAccessorInterface $stateAccessor);
 
     /**
+     * @return bool
+     */
+    public function hasStateAccessor();
+
+    /**
      * @param string $graph
      */
     public function setGraph($graph);

--- a/tests/Finite/Test/Loader/ArrayLoaderTest.php
+++ b/tests/Finite/Test/Loader/ArrayLoaderTest.php
@@ -179,8 +179,18 @@ class ArrayLoaderTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->object->load($sm);
+    }
 
+    public function testLoadWithCustomStateAccessor()
+    {
+        $sa = $this->getMock('Finite\State\Accessor\PropertyPathStateAccessor', array(), array(), 'CustomAccessor');
 
+        $sm = new StateMachine;
+        $sm->setStateAccessor($sa);
+
+        $this->object->load($sm);
+
+        $this->assertAttributeInstanceOf('CustomAccessor', 'stateAccessor', $sm);
     }
 
     public function testSupports()


### PR DESCRIPTION
Hey,

`ArrayLoader` currently always overwrites state accessor during loading of state machine, this PR attempts to fix that