### PR TITLE
removing unneccessary state accessor initialization in costructor

### DIFF
--- a/src/Finite/Loader/ArrayLoader.php
+++ b/src/Finite/Loader/ArrayLoader.php
@@ -69,7 +69,10 @@ class ArrayLoader implements LoaderInterface
             $this->callbackBuilderFactory = new CallbackBuilderFactory();
         }
 
-        $stateMachine->setStateAccessor(new PropertyPathStateAccessor($this->config['property_path']));
+        if (!$stateMachine->hasStateAccessor()) {
+            $stateMachine->setStateAccessor(new PropertyPathStateAccessor($this->config['property_path']));
+        }
+
         $stateMachine->setGraph($this->config['graph']);
 
         $this->loadStates($stateMachine);

--- a/src/Finite/StateMachine/StateMachine.php
+++ b/src/Finite/StateMachine/StateMachine.php
@@ -339,6 +339,14 @@ class StateMachine implements StateMachineInterface
     /**
      * {@inheritdoc}
      */
+    public function hasStateAccessor()
+    {
+        return null !== $this->stateAccessor;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function setGraph($graph)
     {
         $this->graph = $graph;

--- a/src/Finite/StateMachine/StateMachineInterface.php
+++ b/src/Finite/StateMachine/StateMachineInterface.php
@@ -112,6 +112,11 @@ interface StateMachineInterface
     public function setStateAccessor(StateAccessorInterface $stateAccessor);
 
     /**
+     * @return bool
+     */
+    public function hasStateAccessor();
+
+    /**
      * @param string $graph
      */
     public function setGraph($graph);


### PR DESCRIPTION
This should fix issue described in #117 . I have tried different initializations on my end and seems everything is fine.

@stephenjwinn Can you please confirm if this does indeed fix your issue?
@yohang Can you please confirm this does not break something I am not aware of? It should not since you need to bind an object to the state machine first where the state accessor is set to the default one
