### PR TITLE
Update symfony.rst

### DIFF
--- a/docs/usage/symfony.rst
+++ b/docs/usage/symfony.rst
@@ -4,6 +4,8 @@ Use with Symfony
 Installation
 ------------
 
+The bundle does not require a separate Composer package, as it's shipped within `yohang/finite`:
+
 .. code-block:: bash
 
     $ composer require yohang/finite


### PR DESCRIPTION
Perhaps explicitly stating that the bundle is already included within the base package is worth noting, as this is not so typical (usually you'd have to require the bundle separately).
