### PR TITLE
Update symfony.rst

### DIFF
--- a/docs/usage/symfony.rst
+++ b/docs/usage/symfony.rst
@@ -54,9 +54,9 @@ Configuration
                 refused:  { type: final,   properties: { visible: false } }
 
             transitions:
-                propose:  { from: draft,    to: proposed }
-                accept:   { from: proposed, to: accepted }
-                refuse:   { from: proposed, to: refused  }
+                propose:  { from: [ draft ],    to: proposed }
+                accept:   { from: [ proposed ], to: accepted }
+                refuse:   { from: [ proposed ], to: refused  }
 
 
 At this point, your graph is ready and you can start using your workflow on your object.


### PR DESCRIPTION
Transitions require an array as `from` option, but strings were passed in the sample instead.
