### PR TITLE
Fix for multiple-graph example

### DIFF
--- a/src/Finite/Loader/ArrayLoader.php
+++ b/src/Finite/Loader/ArrayLoader.php
@@ -69,7 +69,7 @@ class ArrayLoader implements LoaderInterface
             $this->callbackBuilderFactory = new CallbackBuilderFactory();
         }
 
-        if (!$stateMachine->hasStateAccessor()) {
+        if (!$stateMachine->hasStateAccessor() || $this->config['property_path'] != 'finiteState') {
             $stateMachine->setStateAccessor(new PropertyPathStateAccessor($this->config['property_path']));
         }
 


### PR DESCRIPTION
The ArrayLoader now overwrites the StateMachine's stateAccessor when the property path of the config isn't `finiteState`. This might cause issues when the StateMachine has a different stateAccessor than the PropertyPathStateAccessor.
