### PR TITLE
Feature: callbacks on states and transitions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: php
 sudo: false
+# disabled old php build (http://php.net/eol.php)
 php:
-    - 5.3
-    - 5.4
-    - 5.5
     - 5.6
     - 7
     - hhvm

--- a/src/Finite/Bundle/FiniteBundle/DependencyInjection/Compiler/ContainerCallbackPass.php
+++ b/src/Finite/Bundle/FiniteBundle/DependencyInjection/Compiler/ContainerCallbackPass.php
@@ -2,6 +2,7 @@
 
 namespace Finite\Bundle\FiniteBundle\DependencyInjection\Compiler;
 
+use Finite\Event\Callback\Callback;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -24,14 +25,14 @@ class ContainerCallbackPass implements CompilerPassInterface
             $definition = $container->getDefinition($id);
             $config = $definition->getArgument(0);
             if (isset($config['callbacks'])) {
-                foreach (array('before', 'after') as $position) {
+                foreach (array(Callback::CLAUSE_BEFORE, Callback::CLAUSE_AFTER) as $position) {
                     foreach ($config['callbacks'][$position] as &$callback) {
                         if (
-                            is_array($callback['do'])
-                            && 0 === strpos($callback['do'][0], '@')
-                            && $container->hasDefinition(substr($callback['do'][0], 1))
+                            is_array($callback[Callback::CLAUSE_DO])
+                            && 0 === strpos($callback[Callback::CLAUSE_DO][0], '@')
+                            && $container->hasDefinition(substr($callback[Callback::CLAUSE_DO][0], 1))
                         ) {
-                            $callback['do'][0] = new Reference(substr($callback['do'][0], 1));
+                            $callback[Callback::CLAUSE_DO][0] = new Reference(substr($callback[Callback::CLAUSE_DO][0], 1));
                         }
                     }
                 }

--- a/src/Finite/Bundle/FiniteBundle/DependencyInjection/Configuration.php
+++ b/src/Finite/Bundle/FiniteBundle/DependencyInjection/Configuration.php
@@ -2,6 +2,7 @@
 
 namespace Finite\Bundle\FiniteBundle\DependencyInjection;
 
+use Finite\Event\Callback\Callback;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
@@ -86,8 +87,8 @@ class Configuration implements ConfigurationInterface
     protected function addCallbackSection(NodeBuilder $rootProto)
     {
         $callbacks = $rootProto->arrayNode('callbacks')->children();
-        $this->addSubCallbackSection($callbacks, 'before');
-        $this->addSubCallbackSection($callbacks, 'after');
+        $this->addSubCallbackSection($callbacks, Callback::CLAUSE_BEFORE);
+        $this->addSubCallbackSection($callbacks, Callback::CLAUSE_AFTER);
         $callbacks->end()->end();
     }
 

--- a/src/Finite/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtension.php
+++ b/src/Finite/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtension.php
@@ -2,6 +2,7 @@
 
 namespace Finite\Bundle\FiniteBundle\DependencyInjection;
 
+use Finite\Event\Callback\Callback;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader;
@@ -68,7 +69,7 @@ class FiniteFiniteExtension extends Extension
             return $config;
         }
 
-        foreach (array('before', 'after') as $position) {
+        foreach (array(Callback::CLAUSE_BEFORE, Callback::CLAUSE_AFTER) as $position) {
             foreach ($config['callbacks'][$position] as $i => $callback) {
                 if ($callback['disabled']) {
                     unset($config['callbacks'][$position][$i]);

--- a/src/Finite/Bundle/FiniteBundle/Resources/config/services.xml
+++ b/src/Finite/Bundle/FiniteBundle/Resources/config/services.xml
@@ -42,5 +42,4 @@
             <tag name="twig.extension" />
         </service>
     </services>
-
 </container>

--- a/src/Finite/Event/Callback/Callback.php
+++ b/src/Finite/Event/Callback/Callback.php
@@ -15,15 +15,15 @@ class Callback implements CallbackInterface
     private $specification;
 
     /**
-     * @var callable
+     * @var array callable
      */
     private $callable;
 
     /**
      * @param CallbackSpecificationInterface $callbackSpecification
-     * @param callable                       $callable
+     * @param array $callable
      */
-    public function __construct(CallbackSpecificationInterface $callbackSpecification, $callable)
+    public function __construct(CallbackSpecificationInterface $callbackSpecification, array $callable)
     {
         $this->specification = $callbackSpecification;
         $this->callable = $callable;
@@ -35,6 +35,22 @@ class Callback implements CallbackInterface
     public function getSpecification()
     {
         return $this->specification;
+    }
+
+    /**
+     * @return array callable
+     */
+    public function getCallbacks()
+    {
+        return $this->callable;
+    }
+
+    /**
+     * @return array
+     */
+    public function getClauses()
+    {
+        return $this->specification->getClauses();
     }
 
     /**

--- a/src/Finite/Event/Callback/Callback.php
+++ b/src/Finite/Event/Callback/Callback.php
@@ -9,6 +9,13 @@ use Finite\Event\TransitionEvent;
  */
 class Callback implements CallbackInterface
 {
+    const CLAUSE_AFTER = 'after';
+    const CLAUSE_BEFORE = 'before';
+    const CLAUSE_FROM = 'from';
+    const CLAUSE_TO = 'to';
+    const CLAUSE_ON = 'on';
+    const CLAUSE_DO = 'do';
+
     /**
      * @var CallbackSpecificationInterface
      */

--- a/src/Finite/Event/Callback/Callback.php
+++ b/src/Finite/Event/Callback/Callback.php
@@ -28,9 +28,9 @@ class Callback implements CallbackInterface
 
     /**
      * @param CallbackSpecificationInterface $callbackSpecification
-     * @param array $callable
+     * @param $callable
      */
-    public function __construct(CallbackSpecificationInterface $callbackSpecification, array $callable)
+    public function __construct(CallbackSpecificationInterface $callbackSpecification, $callable)
     {
         $this->specification = $callbackSpecification;
         $this->callable = $callable;

--- a/src/Finite/Event/Callback/CallbackInterface.php
+++ b/src/Finite/Event/Callback/CallbackInterface.php
@@ -15,4 +15,19 @@ interface CallbackInterface
      * @param TransitionEvent $event
      */
     public function __invoke(TransitionEvent $event);
+
+    /**
+     * @return CallbackSpecificationInterface
+     */
+    public function getSpecification();
+
+    /**
+     * @return array callable
+     */
+    public function getCallbacks();
+
+    /**
+     * @return array
+     */
+    public function getClauses();
 }

--- a/src/Finite/Event/Callback/CallbackSpecification.php
+++ b/src/Finite/Event/Callback/CallbackSpecification.php
@@ -36,7 +36,7 @@ class CallbackSpecification implements CallbackSpecificationInterface
         $isExclusion = function ($str) { return 0 === strpos($str, '-'); };
         $removeDash = function ($str) { return substr($str, 1); };
 
-        foreach (array('from', 'to', 'on') as $clause) {
+        foreach (array(Callback::CLAUSE_FROM, Callback::CLAUSE_TO, Callback::CLAUSE_ON) as $clause) {
             $excludedClause = 'excluded_'.$clause;
 
             $this->specs[$excludedClause] = array_filter(${$clause}, $isExclusion);
@@ -58,9 +58,9 @@ class CallbackSpecification implements CallbackSpecificationInterface
     {
         return
             $event->getStateMachine() === $this->stateMachine &&
-            $this->supportsClause('from', $event->getInitialState()->getName()) &&
-            $this->supportsClause('to', $event->getTransition()->getState()) &&
-            $this->supportsClause('on', $event->getTransition()->getName());
+            $this->supportsClause(Callback::CLAUSE_FROM, $event->getInitialState()->getName()) &&
+            $this->supportsClause(Callback::CLAUSE_TO, $event->getTransition()->getState()) &&
+            $this->supportsClause(Callback::CLAUSE_ON, $event->getTransition()->getName());
     }
 
     /**

--- a/src/Finite/Event/Callback/CallbackSpecification.php
+++ b/src/Finite/Event/Callback/CallbackSpecification.php
@@ -64,6 +64,14 @@ class CallbackSpecification implements CallbackSpecificationInterface
     }
 
     /**
+     * @return array
+     */
+    public function getClauses()
+    {
+        return $this->specs;
+    }
+
+    /**
      * @param string $clause
      * @param string $property
      *

--- a/src/Finite/Event/Callback/CallbackSpecificationInterface.php
+++ b/src/Finite/Event/Callback/CallbackSpecificationInterface.php
@@ -19,4 +19,9 @@ interface CallbackSpecificationInterface
      * @return bool
      */
     public function isSatisfiedBy(TransitionEvent $event);
+
+    /**
+     * @return array
+     */
+    public function getClauses();
 }

--- a/src/Finite/Event/CallbackHandler.php
+++ b/src/Finite/Event/CallbackHandler.php
@@ -40,23 +40,23 @@ class CallbackHandler
         $this->specResolver = new OptionsResolver();
         $this->specResolver->setDefaults(
             array(
-                'on' => self::ALL,
-                'from' => self::ALL,
-                'to' => self::ALL,
+                Callback::CLAUSE_ON => self::ALL,
+                Callback::CLAUSE_FROM => self::ALL,
+                Callback::CLAUSE_TO => self::ALL,
             )
         );
 
-        $this->specResolver->setAllowedTypes('on', array('string', 'array'));
-        $this->specResolver->setAllowedTypes('from', array('string', 'array'));
-        $this->specResolver->setAllowedTypes('to', array('string', 'array'));
+        $this->specResolver->setAllowedTypes(Callback::CLAUSE_ON, array('string', 'array'));
+        $this->specResolver->setAllowedTypes(Callback::CLAUSE_FROM, array('string', 'array'));
+        $this->specResolver->setAllowedTypes(Callback::CLAUSE_TO, array('string', 'array'));
 
         $toArrayNormalizer = function (Options $options, $value) {
             return (array) $value;
         };
 
-        $this->specResolver->setNormalizer('on', $toArrayNormalizer);
-        $this->specResolver->setNormalizer('from', $toArrayNormalizer);
-        $this->specResolver->setNormalizer('to', $toArrayNormalizer);
+        $this->specResolver->setNormalizer(Callback::CLAUSE_ON, $toArrayNormalizer);
+        $this->specResolver->setNormalizer(Callback::CLAUSE_FROM, $toArrayNormalizer);
+        $this->specResolver->setNormalizer(Callback::CLAUSE_TO, $toArrayNormalizer);
     }
 
     /**
@@ -109,7 +109,7 @@ class CallbackHandler
         );
 
         $specs = $this->specResolver->resolve($specs);
-        $callback = CallbackBuilder::create($smOrCallback, $specs['from'], $specs['to'], $specs['on'], $callable)->getCallback();
+        $callback = CallbackBuilder::create($smOrCallback, $specs[Callback::CLAUSE_FROM], $specs[Callback::CLAUSE_TO], $specs[Callback::CLAUSE_ON], $callable)->getCallback();
 
         $this->dispatcher->addListener($event, $callback);
 

--- a/src/Finite/Loader/ArrayLoader.php
+++ b/src/Finite/Loader/ArrayLoader.php
@@ -119,6 +119,10 @@ class ArrayLoader implements LoaderInterface
     {
         $callbacks = [];
 
+        if (empty($this->config['callbacks'][$position])) {
+            return $callbacks;
+        }
+
         foreach ($this->config['callbacks'][$position] as $callbackName => $callback) {
             foreach ([Callback::CLAUSE_FROM, Callback::CLAUSE_TO, Callback::CLAUSE_ON] as $clause) {
                 if (!empty($callback[$clause])) {

--- a/src/Finite/Loader/ArrayLoader.php
+++ b/src/Finite/Loader/ArrayLoader.php
@@ -120,9 +120,12 @@ class ArrayLoader implements LoaderInterface
         $callbacks = [];
 
         foreach ($this->config['callbacks'][$position] as $callbackName => $callback) {
-            foreach ([Callback::CLAUSE_FROM, 'to', 'on'] as $caluse) {
-                if (!empty($callback[$caluse][1]) && $callback[$caluse][1] == $triggerName) {
-                    $callbacks[] = [$callbackName => $callback];
+            foreach ([Callback::CLAUSE_FROM, Callback::CLAUSE_TO, Callback::CLAUSE_ON] as $clause) {
+                if (!empty($callback[$clause])) {
+                    if ((is_string($callback[$clause]) && $callback[$clause] === $triggerName)
+                        || (is_array($callback[$clause]) && in_array($triggerName, $callback[$clause]))) {
+                        $callbacks[] = [$callbackName => $callback];
+                    }
                 }
             }
         }

--- a/src/Finite/State/State.php
+++ b/src/Finite/State/State.php
@@ -28,6 +28,13 @@ class State implements StateInterface
     protected $transitions;
 
     /**
+     * Callbacks of the state
+     *
+     * @var array
+     */
+    protected $callbacks;
+
+    /**
      * The state name.
      *
      * @var string
@@ -39,12 +46,27 @@ class State implements StateInterface
      */
     protected $properties;
 
-    public function __construct($name, $type = self::TYPE_NORMAL, array $transitions = array(), array $properties = array())
-    {
+    /**
+     * State constructor.
+     *
+     * @param $name
+     * @param string $type
+     * @param array $transitions
+     * @param array $properties
+     * @param array $callbacks
+     */
+    public function __construct(
+        $name,
+        $type = self::TYPE_NORMAL,
+        array $transitions = [],
+        array $properties = [],
+        array $callbacks = []
+    ) {
         $this->name = $name;
         $this->type = $type;
         $this->transitions = $transitions;
         $this->properties = $properties;
+        $this->callbacks = $callbacks;
     }
 
     /**
@@ -161,6 +183,14 @@ class State implements StateInterface
     public function setProperties(array $properties)
     {
         $this->properties = $properties;
+    }
+
+    /**
+     * @return array
+     */
+    public function getCallbacks()
+    {
+        return $this->callbacks;
     }
 
     /**

--- a/src/Finite/State/StateInterface.php
+++ b/src/Finite/State/StateInterface.php
@@ -69,4 +69,9 @@ interface StateInterface extends PropertiesAwareInterface
      * @deprecated Deprecated since version 1.0.0-BETA2. Use {@link StateMachine::can($transition)} instead.
      */
     public function can($transition);
+
+    /**
+     * @return array
+     */
+    public function getCallbacks();
 }

--- a/src/Finite/StateMachine/StateMachine.php
+++ b/src/Finite/StateMachine/StateMachine.php
@@ -407,72 +407,14 @@ class StateMachine implements StateMachineInterface
      */
     public function getCallbacks()
     {
-        if (empty($this->callbacks)) {
-            $this->setCallbacks();
-        }
-
         return $this->callbacks;
     }
 
     /**
      * @return array
      */
-    protected function setCallbacks()
+    public function setCallbacks($callbacks)
     {
-        $listeners = [
-            FiniteEvents::PRE_TRANSITION,
-            FiniteEvents::POST_TRANSITION,
-        ];
-
-        $callbacks = [];
-
-        foreach ($listeners as $listener) {
-            $events = $this->getDispatcher()->getListeners($listener);
-
-            foreach ($events as $event) {
-                if ($event instanceof Callback) {
-                    $callbacks = array_merge($callbacks, $this->getCallbackData($event, $listener));
-                }
-            }
-        }
-
         $this->callbacks = $callbacks;
-
-        return $this->callbacks;
-    }
-
-    /**
-     * @param Callback $event
-     * @param string $listener
-     *
-     * @return array
-     */
-    protected function getCallbackData(Callback $event, $listener)
-    {
-        $eventCallbacks = $event->getCallbacks();
-        $clauses = $event->getSpecification()->getClauses();
-
-        $callback = [
-            'class' => get_class($eventCallbacks[0]),
-            'method' => $eventCallbacks[1],
-        ];
-
-        $callbacks = [];
-
-        foreach ($clauses as $clauseKey => $clauseValue) {
-            if (!empty($clauseValue)) {
-                foreach ($clauseValue as $name) {
-                    $callbacks[] = [
-                        'name' => $name,
-                        'listener' => $listener,
-                        'clause' => $clauseKey,
-                        'class' => $callback['class'],
-                        'method' => $callback['method'],
-                    ];
-                }
-            }
-        }
-
-        return $callbacks;
     }
 }

--- a/src/Finite/StateMachine/StateMachineInterface.php
+++ b/src/Finite/StateMachine/StateMachineInterface.php
@@ -135,5 +135,10 @@ interface StateMachineInterface
     /**
      * @return array
      */
+    public function setCallbacks($callbacks);
+
+    /**
+     * @return array
+     */
     public function getCallbacks();
 }

--- a/src/Finite/StateMachine/StateMachineInterface.php
+++ b/src/Finite/StateMachine/StateMachineInterface.php
@@ -131,4 +131,9 @@ interface StateMachineInterface
      * @return bool
      */
     public function findStateWithProperty($property, $value = null);
+
+    /**
+     * @return array
+     */
+    public function getCallbacks();
 }

--- a/src/Finite/Transition/Transition.php
+++ b/src/Finite/Transition/Transition.php
@@ -44,18 +44,25 @@ class Transition implements PropertiesAwareTransitionInterface
     protected $propertiesOptionsResolver;
 
     /**
+     * @var array
+     */
+    protected $callbacks;
+
+    /**
      * @param string          $name
      * @param string|array    $initialStates
      * @param string          $state
      * @param callable|null   $guard
      * @param OptionsResolver $propertiesOptionsResolver
+     * @param array           $callbacks
      */
     public function __construct(
         $name,
         $initialStates,
         $state,
         $guard = null,
-        OptionsResolver $propertiesOptionsResolver = null
+        OptionsResolver $propertiesOptionsResolver = null,
+        array $callbacks = []
     ) {
         if (null !== $guard && !is_callable($guard)) {
             throw new \InvalidArgumentException('Invalid callable guard argument passed to Transition::__construct().');
@@ -66,6 +73,7 @@ class Transition implements PropertiesAwareTransitionInterface
         $this->initialStates = (array) $initialStates;
         $this->guard = $guard;
         $this->propertiesOptionsResolver = $propertiesOptionsResolver ?: new OptionsResolver();
+        $this->callbacks = $callbacks;
     }
 
     /**
@@ -176,6 +184,14 @@ class Transition implements PropertiesAwareTransitionInterface
             $this->propertiesOptionsResolver->resolve($options),
             array_combine($missingOptions, $missingOptions)
         );
+    }
+
+    /**
+     * @return array
+     */
+    public function getCallbacks()
+    {
+        return $this->callbacks;
     }
 
     /**

--- a/src/Finite/Transition/TransitionInterface.php
+++ b/src/Finite/Transition/TransitionInterface.php
@@ -47,4 +47,10 @@ interface TransitionInterface
      * @return callable
      */
     public function getGuard();
+
+    /**
+     * Returns properties in the transition.
+     * return mixed
+     */
+    public function getProperties();
 }


### PR DESCRIPTION
The purpose of this pull request is to make it painless to display callback informations for states and transitions. Personally i use this to extend the information on my graphviz graphs.
- extended the interfaces
- added method on state machine to list all callbacks
- added method on states and transitions to list their callbacks
- global callbacks are ignored
