### PR TITLE
Feature: Add a clear method

### DIFF
--- a/src/Finite/Factory/AbstractFactory.php
+++ b/src/Finite/Factory/AbstractFactory.php
@@ -73,4 +73,12 @@ abstract class AbstractFactory implements FactoryInterface
      * @return StateMachineInterface
      */
     abstract protected function createStateMachine();
+
+    /**
+     * Clears all the machines.
+     */
+    public function clear()
+    {
+        $this->stateMachines = array();
+    }
 }

--- a/src/Finite/Factory/FactoryInterface.php
+++ b/src/Finite/Factory/FactoryInterface.php
@@ -20,4 +20,9 @@ interface FactoryInterface
      * @return StateMachineInterface
      */
     public function get($object, $graph = 'default');
+
+    /**
+     * Clears all the machines.
+     */
+    public function clear();
 }


### PR DESCRIPTION
Use case :
I am using a consumer to apply some events, from a queue, on entities who have a workflow.
This consumer stay open a long time.
This consumer was using a lot of memory as the state machines are never deleted. Further more, after some time, even if i delete the references in my code, the php garbage collector cannot free the state machines because of the reference in the factory and he start to take a long time trying to free objects.

With this new method, i can free the state machines and the memory consumption stay low.
