### PR TITLE
Pass transition parameters to the process method

### DIFF
--- a/src/Finite/StateMachine/StateMachine.php
+++ b/src/Finite/StateMachine/StateMachine.php
@@ -131,7 +131,7 @@ class StateMachine implements StateMachineInterface
 
         $this->dispatchTransitionEvent($transition, $event, FiniteEvents::PRE_TRANSITION);
 
-        $returnValue = $transition->process($this);
+        $returnValue = $transition->process($this, $parameters);
         $this->stateAccessor->setState($this->object, $transition->getState());
         $this->currentState = $this->getState($transition->getState());
 

--- a/src/Finite/Transition/Transition.php
+++ b/src/Finite/Transition/Transition.php
@@ -99,7 +99,7 @@ class Transition implements PropertiesAwareTransitionInterface
     /**
      * {@inheritdoc}
      */
-    public function process(StateMachineInterface $stateMachine)
+    public function process(StateMachineInterface $stateMachine, array $parameters)
     {
     }
 

--- a/src/Finite/Transition/TransitionInterface.php
+++ b/src/Finite/Transition/TransitionInterface.php
@@ -32,7 +32,7 @@ interface TransitionInterface
      *
      * @return mixed
      */
-    public function process(StateMachineInterface $stateMachine);
+    public function process(StateMachineInterface $stateMachine, array $parameters);
 
     /**
      * Returns the name of the transition.


### PR DESCRIPTION
Currently, the `process` method of the transitions doesn't receive the parameters sent through `apply`, and it could be very useful in some situations, as mentioned in #116.

It's a BC break because it modifies the `TransitionInterface`, but I hope to see it in a future version.

@yohang do you think the properties should be resolved before passing it to `process`?