### PR TITLE
[ci skip] Get more Open Source Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Finite is a Simple State Machine, written in PHP. It can manage any Stateful obj
 [![Dependency Status](https://www.versioneye.com/php/yohang:finite/1.0.3/badge.svg)](https://www.versioneye.com/php/yohang:finite/1.0.3)
 [![Reference Status](https://www.versioneye.com/php/yohang:finite/reference_badge.svg?style=flat)](https://www.versioneye.com/php/yohang:finite/references)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/yohang/Finite?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Help Contribute to Open Source](https://www.codetriage.com/yohang/finite/badges/users.svg)](https://www.codetriage.com/yohang/finite)
 
 Features
 --------


### PR DESCRIPTION
[CodeTriage](https://www.codetriage.com/) is an app I have maintained
for the past 4-5 years with the goal of getting people involved in
Open Source projects like this one. The app sends subscribers a random
open issue for them to help "triage". For some languages you can also
suggested areas to add documentation.

The initial approach was inspired by seeing the work of the small
core team spending countless hours asking "what version was
this in" and "can you give us an example app". The idea is to
outsource these small interactions to a huge team of volunteers
and let the core team focus on their work.

I want to add a badge to the README of this project. The idea is to
provide an easy link for people to get started contributing to this
project. A badge indicates the number of people currently subscribed
to help the repo. The color is based off of open issues in the project.

Here are some examples of other projects that have a badge in their
README:

- https://github.com/crystal-lang/crystal
- https://github.com/rails/rails
- https://github.com/codetriage/codetriage

Thanks for building open source software, I would love to help you find some helpers.