### PR TITLE
Forcing State::getName to return a string.

### DIFF
--- a/src/Finite/State/State.php
+++ b/src/Finite/State/State.php
@@ -152,7 +152,7 @@ class State implements StateInterface
      */
     public function getName()
     {
-        return $this->name;
+        return (string) $this->name;
     }
 
     /**


### PR DESCRIPTION
I have a specific case where numbers (integers) are used as state names.

For some reason creating the state machine even with integers as strings, like "0" or "10", will make getName()/__toString() fail because it does not return a string.