### PR TITLE
Drop support for PHP 5.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 vendor
 build
 bin
@@ -6,3 +7,4 @@ composer.lock
 cache.properties
 coverage.clover
 docs/_build
+Makefile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: php
 sudo: false
 php:
-    - 5.5
-    - 5.6
-    - 7.0
-    - 7.1
-    - hhvm
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
+  - hhvm
 
 before_install:
   - composer self-update
@@ -17,8 +19,8 @@ script:
   - ./bin/phpunit --coverage-clover=coverage.clover
 
 after_script:
-    - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
-    - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then wget https://scrutinizer-ci.com/ocular.phar; fi
+  - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
 
 notifications:
   email: false

--- a/composer.json
+++ b/composer.json
@@ -1,49 +1,58 @@
 {
-    "name":        "yohang/finite",
-    "description": "A simple PHP5.3+ Finite State Machine",
-    "keywords":    ["statemachine", "workflow", "state", "transition", "symfony", "bundle"],
-    "homepage":    "https://github.com/yohang/Finite",
-    "type":        "library",
-    "license":     "MIT",
-    "authors": [
-        {
-            "name":     "Yohan Giarelli",
-            "email":    "yohan@giarel.li",
-            "homepage": "http://yohan.giarel.li"
-        },
-        {
-            "name":     "Finite contributors",
-            "homepage": "https://github.com/yohang/Finite/graphs/contributors"
-        }
-    ],
-    "require": {
-        "php":                      ">=5.5",
-        "symfony/options-resolver": "^2.6|^3.0|^4.0",
-        "symfony/event-dispatcher": "^2.6|^3.0|^4.0",
-        "symfony/property-access":  "^2.6|^3.0|^4.0"
+  "name": "yohang/finite",
+  "description": "A simple PHP5.6+ Finite State Machine",
+  "keywords": [
+    "statemachine",
+    "workflow",
+    "state",
+    "transition",
+    "symfony",
+    "bundle"
+  ],
+  "homepage": "https://github.com/yohang/Finite",
+  "type": "library",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Yohan Giarelli",
+      "email": "yohan@giarel.li",
+      "homepage": "http://yohan.giarel.li"
     },
-    "require-dev": {
-        "phpunit/phpunit":              "^4.0",
-        "pimple/pimple":                "^1.0",
-        "symfony/dependency-injection": "^2.6|^3.0|^4.0",
-        "symfony/framework-bundle":     "^2.6|^3.0|^4.0",
-        "symfony/security":             "^2.6|^3.0|^4.0",
-        "twig/twig":                    "^1.13"
-    },
-    "suggest": {
-        "pimple/pimple":    "Needed for use with PimpleFactory",
-        "symfony/security": "Needed for using SecurityAwareStateMachine",
-        "symfony/yaml":     "Yaml allows you to define your State graph in YAML"
-    },
-    "autoload": {
-        "psr-0": { "Finite": "src/" }
-    },
-    "config": {
-        "bin-dir":"bin"
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.1.x-dev"
-        }
+    {
+      "name": "Finite contributors",
+      "homepage": "https://github.com/yohang/Finite/graphs/contributors"
     }
+  ],
+  "require": {
+    "php": ">=5.6",
+    "symfony/options-resolver": "^2.6|^3.0|^4.0",
+    "symfony/event-dispatcher": "^2.6|^3.0|^4.0",
+    "symfony/property-access": "^2.6|^3.0|^4.0",
+    "phpunit/phpunit": "^5.7"
+  },
+  "require-dev": {
+    "pimple/pimple": "^1.0",
+    "symfony/dependency-injection": "^2.6|^3.0|^4.0",
+    "symfony/framework-bundle": "^2.6|^3.0|^4.0",
+    "symfony/security": "^2.6|^3.0|^4.0",
+    "twig/twig": "^1.13"
+  },
+  "suggest": {
+    "pimple/pimple": "Needed for use with PimpleFactory",
+    "symfony/security": "Needed for using SecurityAwareStateMachine",
+    "symfony/yaml": "Yaml allows you to define your State graph in YAML"
+  },
+  "autoload": {
+    "psr-0": {
+      "Finite": "src/"
+    }
+  },
+  "config": {
+    "bin-dir": "bin"
+  },
+  "extra": {
+    "branch-alias": {
+      "dev-master": "1.1.x-dev"
+    }
+  }
 }

--- a/src/Finite/StateMachine/StateMachine.php
+++ b/src/Finite/StateMachine/StateMachine.php
@@ -34,14 +34,14 @@ class StateMachine implements StateMachineInterface
      *
      * @var array
      */
-    protected $states = array();
+    protected $states = [];
 
     /**
      * The available transitions.
      *
      * @var array
      */
-    protected $transitions = array();
+    protected $transitions = [];
 
     /**
      * The current state.
@@ -92,10 +92,12 @@ class StateMachine implements StateMachineInterface
         try {
             $initialState = $this->stateAccessor->getState($this->object);
         } catch (Exception\NoSuchPropertyException $e) {
-            throw new Exception\ObjectException(sprintf(
-               'StateMachine can\'t be initialized because the defined property_path of object "%s" does not exist.',
-                get_class($this->object)
-            ), $e->getCode(), $e);
+            throw new Exception\ObjectException(
+                sprintf(
+                    'StateMachine can\'t be initialized because the defined property_path of object "%s" does not exist.',
+                    get_class($this->object)
+                ), $e->getCode(), $e
+            );
         }
 
         if (null === $initialState) {
@@ -115,18 +117,20 @@ class StateMachine implements StateMachineInterface
      *
      * @throws Exception\StateException
      */
-    public function apply($transitionName, array $parameters = array())
+    public function apply($transitionName, array $parameters = [])
     {
         $transition = $this->getTransition($transitionName);
         $event = new TransitionEvent($this->getCurrentState(), $transition, $this, $parameters);
         if (!$this->can($transition, $parameters)) {
-            throw new Exception\StateException(sprintf(
-                'The "%s" transition can not be applied to the "%s" state of object "%s" with graph "%s".',
-                $transition->getName(),
-                $this->currentState->getName(),
-                get_class($this->getObject()),
-                $this->getGraph()
-            ));
+            throw new Exception\StateException(
+                sprintf(
+                    'The "%s" transition can not be applied to the "%s" state of object "%s" with graph "%s".',
+                    $transition->getName(),
+                    $this->currentState->getName(),
+                    get_class($this->getObject()),
+                    $this->getGraph()
+                )
+            );
         }
 
         $this->dispatchTransitionEvent($transition, $event, FiniteEvents::PRE_TRANSITION);
@@ -143,7 +147,7 @@ class StateMachine implements StateMachineInterface
     /**
      * {@inheritdoc}
      */
-    public function can($transition, array $parameters = array())
+    public function can($transition, array $parameters = [])
     {
         $transition = $transition instanceof TransitionInterface ? $transition : $this->getTransition($transition);
 
@@ -180,7 +184,7 @@ class StateMachine implements StateMachineInterface
     {
         if ((null === $initialState || null === $finalState) && !$transition instanceof TransitionInterface) {
             throw new \InvalidArgumentException(
-                'You must provide a TransitionInterface instance or the $transition, '.
+                'You must provide a TransitionInterface instance or the $transition, ' .
                 '$initialState and $finalState parameters'
             );
         }
@@ -220,12 +224,14 @@ class StateMachine implements StateMachineInterface
     public function getTransition($name)
     {
         if (!isset($this->transitions[$name])) {
-            throw new Exception\TransitionException(sprintf(
-                'Unable to find a transition called "%s" on object "%s" with graph "%s".',
-                $name,
-                get_class($this->getObject()),
-                $this->getGraph()
-            ));
+            throw new Exception\TransitionException(
+                sprintf(
+                    'Unable to find a transition called "%s" on object "%s" with graph "%s".',
+                    $name,
+                    $this->getObject() ? get_class($this->getObject()) : 'undefined',
+                    $this->getGraph()
+                )
+            );
         }
 
         return $this->transitions[$name];
@@ -236,15 +242,17 @@ class StateMachine implements StateMachineInterface
      */
     public function getState($name)
     {
-        $name = (string) $name;
+        $name = (string)$name;
 
         if (!isset($this->states[$name])) {
-            throw new Exception\StateException(sprintf(
-                'Unable to find a state called "%s" on object "%s" with graph "%s".',
-                $name,
-                get_class($this->getObject()),
-                $this->getGraph()
-            ));
+            throw new Exception\StateException(
+                sprintf(
+                    'Unable to find a state called "%s" on object "%s" with graph "%s".',
+                    $name,
+                    $this->getObject() ? get_class($this->getObject()) : 'undefined',
+                    $this->getGraph()
+                )
+            );
         }
 
         return $this->states[$name];
@@ -305,11 +313,13 @@ class StateMachine implements StateMachineInterface
             }
         }
 
-        throw new Exception\StateException(sprintf(
-            'No initial state found on object "%s" with graph "%s".',
-            get_class($this->getObject()),
-            $this->getGraph()
-        ));
+        throw new Exception\StateException(
+            sprintf(
+                'No initial state found on object "%s" with graph "%s".',
+                get_class($this->getObject()),
+                $this->getGraph()
+            )
+        );
     }
 
     /**
@@ -392,15 +402,15 @@ class StateMachine implements StateMachineInterface
      * Dispatches event for the transition
      *
      * @param TransitionInterface $transition
-     * @param TransitionEvent $event
-     * @param type $transitionState
+     * @param TransitionEvent     $event
+     * @param type                $transitionState
      */
     private function dispatchTransitionEvent(TransitionInterface $transition, TransitionEvent $event, $transitionState)
     {
         $this->dispatcher->dispatch($transitionState, $event);
-        $this->dispatcher->dispatch($transitionState.'.'.$transition->getName(), $event);
+        $this->dispatcher->dispatch($transitionState . '.' . $transition->getName(), $event);
         if (null !== $this->getGraph()) {
-            $this->dispatcher->dispatch($transitionState.'.'.$this->getGraph().'.'.$transition->getName(), $event);
+            $this->dispatcher->dispatch($transitionState . '.' . $this->getGraph() . '.' . $transition->getName(), $event);
         }
     }
 }

--- a/tests/Finite/Test/Bundle/FiniteBundle/DependencyInjection/Compiler/ContainerCallbackPassTest.php
+++ b/tests/Finite/Test/Bundle/FiniteBundle/DependencyInjection/Compiler/ContainerCallbackPassTest.php
@@ -2,7 +2,9 @@
 
 namespace Finite\Test\Bundle\FiniteBundle\DependencyInjection\Compiler;
 
+use Closure;
 use Finite\Bundle\FiniteBundle\DependencyInjection\Compiler\ContainerCallbackPass;
+use PHPUnit_Framework_TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
@@ -12,7 +14,7 @@ use Symfony\Component\DependencyInjection\Reference;
  *
  * @author Alexandre Bacco <alexandre.bacco@gmail.com>
  */
-class ContainerCallbackPassTest extends \PHPUnit_Framework_TestCase
+class ContainerCallbackPassTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var ContainerBuilder
@@ -36,35 +38,37 @@ class ContainerCallbackPassTest extends \PHPUnit_Framework_TestCase
 
         $newConfig = $this->container->getDefinition('loader')->getArgument(0);
         $callback = $newConfig['callbacks']['before'][0]['do'][0];
-        $this->assertTrue($callback instanceof Reference);
-        $this->assertEquals('my_service', (string) $callback);
+        $this->assertInstanceOf(Reference::class, $callback);
+        $this->assertEquals('my_service', (string)$callback);
         $this->assertEquals('not_a_service', $newConfig['callbacks']['before'][1]['do'][0]);
-        $this->assertTrue($newConfig['callbacks']['after'][0]['do'] instanceof \Closure);
+        $this->assertInstanceOf(Closure::class, $newConfig['callbacks']['after'][0]['do']);
     }
 
     private function load(ContainerBuilder $container)
     {
         $loader = new Definition();
         $loader->addTag('finite.loader');
-        $loader->addArgument(array(
-            'callbacks' => array(
-                'before' => array(
-                    array(
-                        'do' => array('@my_service', 'myMethod')
-                    ),
-                    array(
-                        'do' => array('not_a_service', 'myMethod')
-                    )
-                ),
-                'after' => array(
-                    array(
-                        'do' => function() {
+        $loader->addArgument(
+            [
+                'callbacks' => [
+                    'before' => [
+                        [
+                            'do' => ['@my_service', 'myMethod'],
+                        ],
+                        [
+                            'do' => ['not_a_service', 'myMethod'],
+                        ],
+                    ],
+                    'after' => [
+                        [
+                            'do' => static function () {
                                 // Not a service
-                            }
-                    )
-                )
-            )
-        ));
+                            },
+                        ],
+                    ],
+                ],
+            ]
+        );
         $container->setDefinition('loader', $loader);
 
         $service = new Definition('\Finite\Bundle\DependencyInjection\Compiler\ContainerCallbackPass');

--- a/tests/Finite/Test/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtensionTest.php
+++ b/tests/Finite/Test/Bundle/FiniteBundle/DependencyInjection/FiniteFiniteExtensionTest.php
@@ -3,6 +3,7 @@
 namespace Finite\Test\Bundle\FiniteBundle\DependencyInjection;
 
 use Finite\Bundle\FiniteBundle\DependencyInjection\FiniteFiniteExtension;
+use PHPUnit_Framework_TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 /**
@@ -10,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  *
  * @author Yohan Giarelli <yohan@frequence-web.fr>
  */
-class FiniteFiniteExtensionTest extends \PHPUnit_Framework_TestCase
+class FiniteFiniteExtensionTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var FiniteFiniteExtension
@@ -24,7 +25,7 @@ class FiniteFiniteExtensionTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->object    = new FiniteFiniteExtension;
+        $this->object = new FiniteFiniteExtension;
         $this->container = new ContainerBuilder;
         $this->object->load($this->getConfig(), $this->container);
     }
@@ -51,89 +52,89 @@ class FiniteFiniteExtensionTest extends \PHPUnit_Framework_TestCase
 
     private function getExpectedConfig()
     {
-        return array(
-            'class'         => 'Stateful1',
-            'graph'         => 'default',
+        return [
+            'class' => 'Stateful1',
+            'graph' => 'default',
             'property_path' => 'finiteState',
-            'states'        => array(
-                'state1' => array(
-                    'type'       => 'initial',
-                    'properties' => array()
-                ),
-                'state2' => array(
-                    'type'       => 'normal',
-                    'properties' => array()
-                ),
-                'state3' => array(
-                    'type'       => 'final',
-                    'properties' => array(
+            'states' => [
+                'state1' => [
+                    'type' => 'initial',
+                    'properties' => [],
+                ],
+                'state2' => [
+                    'type' => 'normal',
+                    'properties' => [],
+                ],
+                'state3' => [
+                    'type' => 'final',
+                    'properties' => [
                         'foo' => true,
                         'bar' => false,
-                    )
-                )
-            ),
-            'transitions'   => array(
-                '1_to_2' => array(
-                    'from' => array('state1'),
-                    'to'   => 'state2',
-                    'properties' => array()
-                ),
-                '2_to_3' => array(
-                    'from' => array('state2'),
-                    'to'   => 'state3',
-                    'properties' => array('foo' => 'bar')
-                ),
-            ),
-            'callbacks'     => array(
-                'before' => array(
-                    'callback1' => array('on' => '1_to_2', 'do' => array('@my.listener.service', 'on1To2'))
-                ),
-                'after'  => array(
-                    'callback2' => array('from' => '-state3', 'to' => array('state2', 'state3'), 'do' => array('@my.listener.service', 'on1To2'))
-                )
-            )
-        );
+                    ],
+                ],
+            ],
+            'transitions' => [
+                '1_to_2' => [
+                    'from' => ['state1'],
+                    'to' => 'state2',
+                    'properties' => [],
+                ],
+                '2_to_3' => [
+                    'from' => ['state2'],
+                    'to' => 'state3',
+                    'properties' => ['foo' => 'bar'],
+                ],
+            ],
+            'callbacks' => [
+                'before' => [
+                    'callback1' => ['on' => '1_to_2', 'do' => ['@my.listener.service', 'on1To2']],
+                ],
+                'after' => [
+                    'callback2' => ['from' => '-state3', 'to' => ['state2', 'state3'], 'do' => ['@my.listener.service', 'on1To2']],
+                ],
+            ],
+        ];
     }
 
     private function getConfig()
     {
-        return array(
-            'finite_finite' => array(
-                'workflow1' => array(
-                    'class'       => 'Stateful1',
-                    'states'      => array(
-                        'state1' => array('type' => 'initial'),
-                        'state2' => array('type' => 'normal'),
-                        'state3' => array(
-                            'type'       => 'final',
-                            'properties' => array(
+        return [
+            'finite_finite' => [
+                'workflow1' => [
+                    'class' => 'Stateful1',
+                    'states' => [
+                        'state1' => ['type' => 'initial'],
+                        'state2' => ['type' => 'normal'],
+                        'state3' => [
+                            'type' => 'final',
+                            'properties' => [
                                 'foo' => true,
                                 'bar' => false,
-                            )
-                        )
-                    ),
-                    'transitions' => array(
-                        '1_to_2' => array(
-                            'from' => array('state1'),
-                            'to'   => 'state2'
-                        ),
-                        '2_to_3' => array(
-                            'from' => array('state2'),
-                            'to'   => 'state3',
-                            'properties' => array('foo' => 'bar'),
-                        ),
-                    ),
-                    'callbacks'   => array(
-                        'before' => array(
-                            'callback1' => array('on' => '1_to_2', 'do' => array('@my.listener.service', 'on1To2'))
-                        ),
-                        'after'  => array(
-                            'callback2' => array('from' => '-state3', 'to' => array('state2', 'state3'), 'do' => array('@my.listener.service', 'on1To2')),
-                            'callback3' => array('disabled' => true)
-                        )
-                    )
-                )
-            )
-        );
+                            ],
+                        ],
+                    ],
+                    'transitions' => [
+                        '1_to_2' => [
+                            'from' => ['state1'],
+                            'to' => 'state2',
+                        ],
+                        '2_to_3' => [
+                            'from' => ['state2'],
+                            'to' => 'state3',
+                            'properties' => ['foo' => 'bar'],
+                        ],
+                    ],
+                    'callbacks' => [
+                        'before' => [
+                            'callback1' => ['on' => '1_to_2', 'do' => ['@my.listener.service', 'on1To2']],
+                        ],
+                        'after' => [
+                            'callback2' => ['from' => '-state3', 'to' => ['state2', 'state3'], 'do' => ['@my.listener.service', 'on1To2']],
+                            'callback3' => ['disabled' => true],
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/tests/Finite/Test/ContextTest.php
+++ b/tests/Finite/Test/ContextTest.php
@@ -3,14 +3,21 @@
 namespace Finite\Test;
 
 use Finite\Context;
+use Finite\Factory\FactoryInterface;
 use Finite\Factory\PimpleFactory;
-use  Finite\StateMachine\StateMachine;
+use Finite\State\Accessor\StateAccessorInterface;
 use Finite\State\State;
+use Finite\StatefulInterface;
+use Finite\StateMachine\StateMachine;
+use Finite\StateMachine\StateMachineInterface;
+use Finite\Transition\TransitionInterface;
+use PHPUnit_Framework_TestCase;
+use Pimple;
 
 /**
  * @author Yohan Giarelli <yohan@frequence-web.fr>
  */
-class ContextTest extends \PHPUnit_Framework_TestCase
+class ContextTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var Context
@@ -21,75 +28,77 @@ class ContextTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->accessor = $accessor = $this->getMock('Finite\State\Accessor\StateAccessorInterface');
-        $container = new \Pimple(array(
-            'state_machine' => function() use ($accessor) {
-                $sm =  new StateMachine(null, null, $accessor);
-                $sm->addState(new State('s1', State::TYPE_INITIAL, array(), array('foo' => true, 'bar' => false)));
-                $sm->addTransition('t12', 's1', 's2');
-                $sm->addTransition('t23', 's2', 's3');
+        $this->accessor = $accessor = $this->createMock(StateAccessorInterface::class);
+        $container = new Pimple(
+            [
+                'state_machine' => static function () use ($accessor) {
+                    $sm = new StateMachine(null, null, $accessor);
+                    $sm->addState(new State('s1', State::TYPE_INITIAL, [], ['foo' => true, 'bar' => false]));
+                    $sm->addTransition('t12', 's1', 's2');
+                    $sm->addTransition('t23', 's2', 's3');
 
-                return $sm;
-            }
-        ));
+                    return $sm;
+                },
+            ]
+        );
 
         $this->object = new Context(new PimpleFactory($container, 'state_machine'));
     }
 
     public function testGetStateMachine()
     {
-        $this->accessor->expects($this->once())->method('getState')->will($this->returnValue('s1'));
-        $sm = $this->object->getStateMachine($this->getMock('Finite\StatefulInterface'));
+        $this->accessor->expects($this->once())->method('getState')->willReturn('s1');
+        $sm = $this->object->getStateMachine($this->createMock(StatefulInterface::class));
 
-        $this->assertInstanceOf('Finite\StateMachine\StateMachine', $sm);
+        $this->assertInstanceOf(StateMachine::class, $sm);
         $this->assertSame('s1', $sm->getCurrentState()->getName());
     }
 
     public function testGetState()
     {
-        $this->accessor->expects($this->once())->method('getState')->will($this->returnValue('s1'));
-        $this->assertSame('s1', $this->object->getState($this->getMock('Finite\StatefulInterface')));
+        $this->accessor->expects($this->once())->method('getState')->willReturn('s1');
+        $this->assertSame('s1', $this->object->getState($this->createMock(StatefulInterface::class)));
     }
 
     public function testGetTransitions()
     {
-        $this->accessor->expects($this->once())->method('getState')->will($this->returnValue('s1'));
-        $this->assertEquals(array('t12'), $this->object->getTransitions($this->getMock('Finite\StatefulInterface')));
+        $this->accessor->expects($this->once())->method('getState')->willReturn('s1');
+        $this->assertEquals(['t12'], $this->object->getTransitions($this->createMock(StatefulInterface::class)));
     }
 
     public function testGetTransitionObjects()
     {
-        $this->accessor->expects($this->once())->method('getState')->will($this->returnValue('s1'));
+        $this->accessor->expects($this->once())->method('getState')->willReturn('s1');
 
-        $transitions = $this->object->getTransitions($this->getMock('Finite\StatefulInterface'), 'default', true);
+        $transitions = $this->object->getTransitions($this->createMock(StatefulInterface::class), 'default', true);
 
         $this->assertCount(1, $transitions);
-        $this->assertInstanceOf('Finite\Transition\TransitionInterface', $transitions[0]);
+        $this->assertInstanceOf(TransitionInterface::class, $transitions[0]);
     }
 
     public function testGetProperties()
     {
-        $this->accessor->expects($this->once())->method('getState')->will($this->returnValue('s1'));
+        $this->accessor->expects($this->once())->method('getState')->willReturn('s1');
         $this->assertEquals(
-            array('foo' => true, 'bar' => false),
-            $this->object->getProperties($this->getMock('Finite\StatefulInterface'))
+            ['foo' => true, 'bar' => false],
+            $this->object->getProperties($this->createMock(StatefulInterface::class))
         );
     }
 
     public function testHasProperty()
     {
-        $this->accessor->expects($this->exactly(2))->method('getState')->will($this->returnValue('s1'));
-        $this->assertTrue($this->object->hasProperty($this->getMock('Finite\StatefulInterface'), 'foo'));
-        $this->assertFalse($this->object->hasProperty($this->getMock('Finite\StatefulInterface'), 'baz'));
+        $this->accessor->expects($this->exactly(2))->method('getState')->willReturn('s1');
+        $this->assertTrue($this->object->hasProperty($this->createMock(StatefulInterface::class), 'foo'));
+        $this->assertFalse($this->object->hasProperty($this->createMock(StatefulInterface::class), 'baz'));
     }
 
     public function testItRetrievesGoodStateMachine()
     {
-        $object  = $this->getMock('Finite\StatefulInterface');
-        $factory = $this->getMock('Finite\Factory\FactoryInterface');
-        $sm      = $this->getMock('Finite\StateMachine\StateMachineInterface');
+        $object = $this->createMock(StatefulInterface::class);
+        $factory = $this->createMock(FactoryInterface::class);
+        $sm = $this->createMock(StateMachineInterface::class);
 
-        $factory->expects($this->once())->method('get')->with($object, 'foo')->will($this->returnValue($sm));
+        $factory->expects($this->once())->method('get')->with(...[$object, 'foo'])->willReturn($sm);
 
         $context = new Context($factory);
         $this->assertSame($sm, $context->getStateMachine($object, 'foo'));

--- a/tests/Finite/Test/Event/Callback/CallbackBuilderFactoryTest.php
+++ b/tests/Finite/Test/Event/Callback/CallbackBuilderFactoryTest.php
@@ -2,20 +2,23 @@
 
 namespace Finite\Test\Event\Callback;
 
+use Finite\Event\Callback\CallbackBuilder;
 use Finite\Event\Callback\CallbackBuilderFactory;
+use Finite\StateMachine\StateMachineInterface;
+use PHPUnit_Framework_TestCase;
 
 /**
  * @author Yohan Giarelli <yohan@frequence-web.fr>
  */
-class CallbackBuilderFactoryTest extends \PHPUnit_Framework_TestCase
+class CallbackBuilderFactoryTest extends PHPUnit_Framework_TestCase
 {
     public function testItConstructsCallbackBuilder()
     {
-        $sm = $this->getMock('Finite\StateMachine\StateMachineInterface');
+        $sm = $this->createMock(StateMachineInterface::class);
 
         $factory = new CallbackBuilderFactory;
 
-        $this->assertInstanceOf('Finite\Event\Callback\CallbackBuilder', $builder = $factory->createBuilder($sm));
+        $this->assertInstanceOf(CallbackBuilder::class, $builder = $factory->createBuilder($sm));
         $this->assertNotSame($builder, $factory->createBuilder($sm));
     }
 }

--- a/tests/Finite/Test/Event/Callback/CallbackBuilderTest.php
+++ b/tests/Finite/Test/Event/Callback/CallbackBuilderTest.php
@@ -2,32 +2,39 @@
 
 namespace Finite\Test\Event\Callback;
 
+use Finite\Event\Callback\Callback;
 use Finite\Event\Callback\CallbackBuilder;
+use Finite\Event\Callback\CallbackSpecification;
+use Finite\StateMachine\StateMachine;
+use PHPUnit_Framework_TestCase;
+use stdClass;
 
 /**
  * @author Yohan Giarelli <yohan@frequence-web.fr>
  */
-class CallbackBuilderTest extends \PHPUnit_Framework_TestCase
+class CallbackBuilderTest extends PHPUnit_Framework_TestCase
 {
     public function testItBuildsCallback()
     {
         $stateMachine = $this
-            ->getMockBuilder('Finite\StateMachine\StateMachine')
+            ->getMockBuilder(StateMachine::class)
             ->disableOriginalConstructor()
-            ->getMock();
+            ->getMock()
+        ;
 
-        $callableMock = $this->getMockBuilder('\stdClass')->setMethods(array('call'))->getMock();
+        $callableMock = $this->getMockBuilder(stdClass::class)->setMethods(['call'])->getMock();
 
-        $callback = CallbackBuilder::create($stateMachine, array($callableMock, 'call'))
-            ->setFrom(array('s1'))
+        $callback = CallbackBuilder::create($stateMachine, [$callableMock, 'call'])
+            ->setFrom(['s1'])
             ->addFrom('s2')
-            ->setTo(array('s2'))
+            ->setTo(['s2'])
             ->addTo('s3')
-            ->setOn(array('t12'))
+            ->setOn(['t12'])
             ->addOn('t23')
-            ->getCallback();
+            ->getCallback()
+        ;
 
-        $this->assertInstanceOf('Finite\Event\Callback\Callback', $callback);
-        $this->assertInstanceOf('Finite\Event\Callback\CallbackSpecification', $callback->getSpecification());
+        $this->assertInstanceOf(Callback::class, $callback);
+        $this->assertInstanceOf(CallbackSpecification::class, $callback->getSpecification());
     }
 }

--- a/tests/Finite/Test/Event/Callback/CallbackSpecificationTest.php
+++ b/tests/Finite/Test/Event/Callback/CallbackSpecificationTest.php
@@ -5,29 +5,31 @@ namespace Finite\Test\Event\Callback;
 use Finite\Event\Callback\CallbackSpecification;
 use Finite\Event\TransitionEvent;
 use Finite\State\State;
+use Finite\StateMachine\StateMachine;
 use Finite\Transition\Transition;
+use PHPUnit_Framework_TestCase;
 
 /**
  * @author Yohan Giarelli <yohan@frequence-web.fr>
  */
-class CallbackSpecificationTest extends \PHPUnit_Framework_TestCase
+class CallbackSpecificationTest extends PHPUnit_Framework_TestCase
 {
     private $stateMachine;
 
     protected function setUp()
     {
-        $this->stateMachine = $this->getMock('Finite\StateMachine\StateMachine');
+        $this->stateMachine = $this->createMock(StateMachine::class);
     }
 
     public function testItIsSatisfiedByFrom()
     {
-        $spec = new CallbackSpecification($this->stateMachine, array('s1', 's2'), array(), array());
+        $spec = new CallbackSpecification($this->stateMachine, ['s1', 's2'], [], []);
 
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
         $this->assertFalse($spec->isSatisfiedBy($this->getTransitionEvent('s3', 't34', 's4')));
 
-        $spec = new CallbackSpecification($this->stateMachine, array('-s3'), array(), array());
+        $spec = new CallbackSpecification($this->stateMachine, ['-s3'], [], []);
 
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
@@ -36,13 +38,13 @@ class CallbackSpecificationTest extends \PHPUnit_Framework_TestCase
 
     public function testItIsSatisfiedByTo()
     {
-        $spec = new CallbackSpecification($this->stateMachine, array(), array('s2', 's3'), array());
+        $spec = new CallbackSpecification($this->stateMachine, [], ['s2', 's3'], []);
 
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
         $this->assertFalse($spec->isSatisfiedBy($this->getTransitionEvent('s3', 't34', 's4')));
 
-        $spec = new CallbackSpecification($this->stateMachine, array(), array('-s4'), array());
+        $spec = new CallbackSpecification($this->stateMachine, [], ['-s4'], []);
 
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
@@ -51,13 +53,13 @@ class CallbackSpecificationTest extends \PHPUnit_Framework_TestCase
 
     public function testItIsSatisfiedByOn()
     {
-        $spec = new CallbackSpecification($this->stateMachine, array(), array(), array('t12', 't23'));
+        $spec = new CallbackSpecification($this->stateMachine, [], [], ['t12', 't23']);
 
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
         $this->assertFalse($spec->isSatisfiedBy($this->getTransitionEvent('s3', 't34', 's4')));
 
-        $spec = new CallbackSpecification($this->stateMachine, array(), array(), array('-t34'));
+        $spec = new CallbackSpecification($this->stateMachine, [], [], ['-t34']);
 
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s1', 't12', 's2')));
         $this->assertTrue($spec->isSatisfiedBy($this->getTransitionEvent('s2', 't23', 's3')));
@@ -75,7 +77,7 @@ class CallbackSpecificationTest extends \PHPUnit_Framework_TestCase
     {
         return new TransitionEvent(
             new State($fromState),
-            new Transition($transition, array($fromState), $toState),
+            new Transition($transition, [$fromState], $toState),
             $this->stateMachine
         );
     }

--- a/tests/Finite/Test/Event/Callback/CallbackTest.php
+++ b/tests/Finite/Test/Event/Callback/CallbackTest.php
@@ -3,38 +3,43 @@
 namespace Finite\Test\Event\Callback;
 
 use Finite\Event\Callback\Callback;
+use Finite\Event\Callback\CallbackSpecification;
+use Finite\Event\TransitionEvent;
+use Finite\StateMachine\StateMachine;
+use PHPUnit_Framework_TestCase;
+use stdClass;
 
 /**
  * @author Yohan Giarelli <yohan@frequence-web.fr>
  */
-class CallbackTest extends \PHPUnit_Framework_TestCase
+class CallbackTest extends PHPUnit_Framework_TestCase
 {
     public function testInvokeWithGoodSpec()
     {
-        $spec         = $this->getMockBuilder('Finite\Event\Callback\CallbackSpecification')->disableOriginalConstructor()->getMock();
-        $callableMock = $this->getMockBuilder('\stdClass')->setMethods(array('call'))->getMock();
-        $event        = $this->getMockBuilder('Finite\Event\TransitionEvent')->disableOriginalConstructor()->getMock();
-        $stateMachine = $this->getMockBuilder('Finite\StateMachine\StateMachine')->disableOriginalConstructor()->getMock();
+        $spec = $this->getMockBuilder(CallbackSpecification::class)->disableOriginalConstructor()->getMock();
+        $callableMock = $this->getMockBuilder(stdClass::class)->setMethods(['call'])->getMock();
+        $event = $this->getMockBuilder(TransitionEvent::class)->disableOriginalConstructor()->getMock();
+        $stateMachine = $this->getMockBuilder(StateMachine::class)->disableOriginalConstructor()->getMock();
 
-        $event->expects($this->once())->method('getStateMachine')->will($this->returnValue($stateMachine));
-        $spec->expects($this->once())->method('isSatisfiedBy')->with($event)->will($this->returnValue(true));
+        $event->expects($this->once())->method('getStateMachine')->willReturn($stateMachine);
+        $spec->expects($this->once())->method('isSatisfiedBy')->with(...[$event])->willReturn(true);
 
         $callableMock->expects($this->once())->method('call');
 
-        $callback = new Callback($spec, array($callableMock, 'call'));
+        $callback = new Callback($spec, [$callableMock, 'call']);
         $callback($event);
     }
 
     public function testInvokeWithBadSpec()
     {
-        $spec         = $this->getMockBuilder('Finite\Event\Callback\CallbackSpecification')->disableOriginalConstructor()->getMock();
-        $callableMock = $this->getMockBuilder('\stdClass')->setMethods(array('call'))->getMock();
-        $event        = $this->getMockBuilder('Finite\Event\TransitionEvent')->disableOriginalConstructor()->getMock();
+        $spec = $this->getMockBuilder(CallbackSpecification::class)->disableOriginalConstructor()->getMock();
+        $callableMock = $this->getMockBuilder(stdClass::class)->setMethods(['call'])->getMock();
+        $event = $this->getMockBuilder(TransitionEvent::class)->disableOriginalConstructor()->getMock();
 
-        $spec->expects($this->once())->method('isSatisfiedBy')->with($event)->will($this->returnValue(false));
+        $spec->expects($this->once())->method('isSatisfiedBy')->with(...[$event])->willReturn(false);
         $callableMock->expects($this->never())->method('call');
 
-        $callback = new Callback($spec, array($callableMock, 'call'));
+        $callback = new Callback($spec, [$callableMock, 'call']);
         $callback($event);
     }
 }

--- a/tests/Finite/Test/Event/TransitionEventTest.php
+++ b/tests/Finite/Test/Event/TransitionEventTest.php
@@ -3,11 +3,15 @@
 namespace Finite\Test\Event;
 
 use Finite\Event\TransitionEvent;
+use Finite\State\State;
+use Finite\StateMachine\StateMachine;
+use Finite\Transition\Transition;
+use PHPUnit_Framework_TestCase;
 
-class TransitionEventTest extends \PHPUnit_Framework_TestCase
+class TransitionEventTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var Finite\Transition\Transition
+     * @var \Finite\Transition\Transition
      */
     protected $transition;
 
@@ -18,25 +22,26 @@ class TransitionEventTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->transition = $this->getMockBuilder('Finite\Transition\Transition')->disableOriginalConstructor()->getMock();
+        $this->transition = $this->getMockBuilder(Transition::class)->disableOriginalConstructor()->getMock();
 
         $this->transition
             ->expects($this->once())
             ->method('resolveProperties')
-            ->with($this->isType('array'))
-            ->will($this->returnValue(array('returned' => 1)));
+            ->with(...[$this->isType('array')])
+            ->willReturn(['returned' => 1])
+        ;
 
         $this->object = new TransitionEvent(
-            $this->getMockBuilder('Finite\State\State')->disableOriginalConstructor()->getMock(),
+            $this->getMockBuilder(State::class)->disableOriginalConstructor()->getMock(),
             $this->transition,
-            $this->getMockBuilder('Finite\StateMachine\StateMachine')->disableOriginalConstructor()->getMock(),
-            array()
+            $this->getMockBuilder(StateMachine::class)->disableOriginalConstructor()->getMock(),
+            []
         );
     }
 
     public function testItResolveProperties()
     {
-        $this->assertSame(array('returned' => 1), $this->object->getProperties());
+        $this->assertSame(['returned' => 1], $this->object->getProperties());
     }
 
     public function testPropertyGetters()

--- a/tests/Finite/Test/Extension/Twig/FiniteExtensionTest.php
+++ b/tests/Finite/Test/Extension/Twig/FiniteExtensionTest.php
@@ -5,13 +5,19 @@ namespace Finite\Test\Extension\Twig;
 use Finite\Context;
 use Finite\Extension\Twig\FiniteExtension;
 use Finite\Factory\PimpleFactory;
-use  Finite\StateMachine\StateMachine;
+use Finite\State\Accessor\StateAccessorInterface;
 use Finite\State\State;
+use Finite\StatefulInterface;
+use Finite\StateMachine\StateMachine;
+use PHPUnit_Framework_TestCase;
+use Pimple;
+use Twig_Environment;
+use Twig_Loader_Array;
 
 /**
  * @author Yohan Giarelli <yohan@frequence-web.fr>
  */
-class FiniteExtensionTest extends \PHPUnit_Framework_TestCase
+class FiniteExtensionTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var \Twig_Environment
@@ -27,69 +33,94 @@ class FiniteExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->accessor = $accessor = $this->getMock('Finite\State\Accessor\StateAccessorInterface');
-        $this->env = new \Twig_Environment(
-            new \Twig_Loader_Array(
-                array(
-                    'state'       => '{{ finite_state(object) }}',
+        $this->accessor = $accessor = $this->createMock(StateAccessorInterface::class);
+        $this->env = new Twig_Environment(
+            new Twig_Loader_Array(
+                [
+                    'state' => '{{ finite_state(object) }}',
                     'transitions' => '{% for transition in finite_transitions(object) %}{{ transition }}{% endfor %}',
-                    'properties'  => '{% for property, val in finite_properties(object) %}{{ property }}{% endfor %}',
-                    'has'         => '{{ finite_has(object, property) ? "yes" : "no" }}',
-                    'can'         => '{{ finite_can(object, transition, "foo") ? "yes" : "no" }}'
-                )
+                    'properties' => '{% for property, val in finite_properties(object) %}{{ property }}{% endfor %}',
+                    'has' => '{{ finite_has(object, property) ? "yes" : "no" }}',
+                    'can' => '{{ finite_can(object, transition, "foo") ? "yes" : "no" }}',
+                ]
             )
         );
 
-        $container = new \Pimple(array(
-            'state_machine' => function() use ($accessor) {
-                $sm =  new StateMachine(null, null, $accessor);
-                $sm->addState(new State('s1', State::TYPE_INITIAL, array(), array('foo' => true, 'bar' => false)));
-                $sm->addTransition('t12', 's1', 's2');
-                $sm->addTransition('t23', 's2', 's3');
+        $container = new Pimple(
+            [
+                'state_machine' => static function () use ($accessor) {
+                    $sm = new StateMachine(null, null, $accessor);
+                    $sm->addState(new State('s1', State::TYPE_INITIAL, [], ['foo' => true, 'bar' => false]));
+                    $sm->addTransition('t12', 's1', 's2');
+                    $sm->addTransition('t23', 's2', 's3');
 
-                return $sm;
-            }
-        ));
+                    return $sm;
+                },
+            ]
+        );
 
-        $this->context = new Context(new PimpleFactory($container, 'state_machine'));;
+        $this->context = new Context(new PimpleFactory($container, 'state_machine'));
         $this->env->addExtension(new FiniteExtension($this->context));
     }
 
+    /**
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
+     */
     public function testState()
     {
-        $this->accessor->expects($this->once())->method('getState')->will($this->returnValue('s1'));
-        $this->assertSame('s1', $this->env->render('state', array('object' => $this->getObjectMock())));
+        $this->accessor->expects($this->once())->method('getState')->willReturn('s1');
+        $this->assertSame('s1', $this->env->render('state', ['object' => $this->getObjectMock()]));
     }
 
+    /**
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
+     */
     public function testTransitions()
     {
-        $this->accessor->expects($this->once())->method('getState')->will($this->returnValue('s1'));
-        $this->assertSame('t12', $this->env->render('transitions', array('object' => $this->getObjectMock())));
+        $this->accessor->expects($this->once())->method('getState')->willReturn('s1');
+        $this->assertSame('t12', $this->env->render('transitions', ['object' => $this->getObjectMock()]));
     }
 
+    /**
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
+     */
     public function testProperties()
     {
-        $this->accessor->expects($this->once())->method('getState')->will($this->returnValue('s1'));
-        $this->assertSame('foobar', $this->env->render('properties', array('object' => $this->getObjectMock())));
+        $this->accessor->expects($this->once())->method('getState')->willReturn('s1');
+        $this->assertSame('foobar', $this->env->render('properties', ['object' => $this->getObjectMock()]));
     }
 
+    /**
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
+     */
     public function testHas()
     {
-        $this->accessor->expects($this->exactly(2))->method('getState')->will($this->returnValue('s1'));
-        $this->assertSame('yes', $this->env->render('has', array('object' => $this->getObjectMock(), 'property' => 'foo')));
-        $this->assertSame('no', $this->env->render('has', array('object' => $this->getObjectMock(), 'property' => 'baz')));
+        $this->accessor->expects($this->exactly(2))->method('getState')->willReturn('s1');
+        $this->assertSame('yes', $this->env->render('has', ['object' => $this->getObjectMock(), 'property' => 'foo']));
+        $this->assertSame('no', $this->env->render('has', ['object' => $this->getObjectMock(), 'property' => 'baz']));
     }
 
+    /**
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
+     */
     public function testCan()
     {
-        $this->assertSame('yes', $this->env->render('can', array('object' => $this->getObjectMock(), 'transition' => 't12')));
-        $this->assertSame('no', $this->env->render('can', array('object' => $this->getObjectMock(), 'transition' => 't23')));
+        $this->assertSame('yes', $this->env->render('can', ['object' => $this->getObjectMock(), 'transition' => 't12']));
+        $this->assertSame('no', $this->env->render('can', ['object' => $this->getObjectMock(), 'transition' => 't23']));
     }
 
     public function getObjectMock()
     {
-        $mock = $this->getMock('Finite\StatefulInterface');
-
-        return $mock;
+        return $this->createMock(StatefulInterface::class);
     }
 }

--- a/tests/Finite/Test/Factory/SymfonyDependencyInjectionFactoryTest.php
+++ b/tests/Finite/Test/Factory/SymfonyDependencyInjectionFactoryTest.php
@@ -2,55 +2,69 @@
 
 namespace Finite\Test\Factory;
 
+use Finite\Exception\FactoryException;
 use Finite\Factory\SymfonyDependencyInjectionFactory;
-use  Finite\StateMachine\StateMachine;
-use Symfony\Component\DependencyInjection\Container;
+use Finite\State\Accessor\StateAccessorInterface;
+use Finite\StatefulInterface;
+use Finite\StateMachine\StateMachine;
+use PHPUnit_Framework_TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
-class SymfonyDependencyInjectionFactoryTest extends \PHPUnit_Framework_TestCase
+class SymfonyDependencyInjectionFactoryTest extends PHPUnit_Framework_TestCase
 {
     /**
-     * @var PimpleFactory
+     * @var \Finite\Factory\PimpleFactory
      */
     protected $object;
 
     protected $accessor;
 
+    /**
+     * @throws \Finite\Exception\FactoryException
+     */
     public function setUp()
     {
-        $this->accessor = $this->getMock('Finite\State\Accessor\StateAccessorInterface');
+        $this->accessor = $this->createMock(StateAccessorInterface::class);
         $container = new ContainerBuilder;
         $container
-            ->register('state_machine', 'Finite\StateMachine\StateMachine')
+            ->register('state_machine', StateMachine::class)
             ->setShared(false)
-            ->setArguments(array(null, null, $this->accessor))
-            ->addMethodCall('addTransition', array('t12', 's1', 's2'))
-            ->addMethodCall('addTransition', array('t23', 's2', 's3'));
+            ->setArguments([null, null, $this->accessor])
+            ->addMethodCall('addTransition', ['t12', 's1', 's2'])
+            ->addMethodCall('addTransition', ['t23', 's2', 's3'])
+        ;
 
         $this->object = new SymfonyDependencyInjectionFactory($container, 'state_machine');
     }
 
     public function testGet()
     {
-        $object = $this->getMock('Finite\StatefulInterface');
-        $this->accessor->expects($this->at(0))->method('getState')->will($this->returnValue('s2'));
+        $object = $this->createMock(StatefulInterface::class);
+
+        $this->accessor->expects($this->at(0))
+            ->method('getState')
+            ->willReturn('s2')
+        ;
+
         $sm = $this->object->get($object);
 
-        $this->assertInstanceOf('Finite\StateMachine\StateMachine', $sm);
+        $this->assertInstanceOf(StateMachine::class, $sm);
         $this->assertSame('s2', $sm->getCurrentState()->getName());
 
-        $object2 = $this->getMock('Finite\StatefulInterface');
-        $this->accessor->expects($this->at(0))->method('getState')->will($this->returnValue('s2'));
+        $object2 = $this->createMock(StatefulInterface::class);
+        $this->accessor->expects($this->at(0))->method('getState')->willReturn('s2');
         $sm2 = $this->object->get($object2);
 
         $this->assertNotSame($sm, $sm2);
     }
 
     /**
-     * @expectedException \Finite\Exception\FactoryException
+     * @throws \Finite\Exception\FactoryException
      */
     public function testNoService()
     {
+        $this->expectException(FactoryException::class);
+
         new SymfonyDependencyInjectionFactory(new ContainerBuilder, 'state_machine');
     }
 }

--- a/tests/Finite/Test/State/Accessor/PropertyPathStateAccessorTest.php
+++ b/tests/Finite/Test/State/Accessor/PropertyPathStateAccessorTest.php
@@ -3,9 +3,12 @@
 namespace Finite\Test\State\Accessor;
 
 use Finite\State\Accessor\PropertyPathStateAccessor;
+use Finite\StatefulInterface;
+use PHPUnit_Framework_TestCase;
 use Symfony\Component\PropertyAccess\Exception\NoSuchPropertyException;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
-class PropertyPathStateAccessorTest extends \PHPUnit_Framework_TestCase
+class PropertyPathStateAccessorTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var \PHPUnit_Framework_MockObject_MockObject
@@ -14,19 +17,23 @@ class PropertyPathStateAccessorTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->propertyAccessor = $this->getMock('Symfony\Component\PropertyAccess\PropertyAccessorInterface');
+        $this->propertyAccessor = $this->createMock(PropertyAccessorInterface::class);
     }
 
+    /**
+     * @throws \Finite\Exception\NoSuchPropertyException
+     */
     public function testGetState()
     {
-        $object   = new PropertyPathStateAccessor('bar', $this->propertyAccessor);
-        $stateful = $this->getMock('Finite\StatefulInterface');
+        $object = new PropertyPathStateAccessor('bar', $this->propertyAccessor);
+        $stateful = $this->createMock(StatefulInterface::class);
 
         $this->propertyAccessor
             ->expects($this->at(0))
             ->method('getValue')
-            ->with($stateful, 'bar')
-            ->will($this->returnValue('foo'));
+            ->with(...[$stateful, 'bar'])
+            ->willReturn('foo')
+        ;
 
         $this->assertSame('foo', $object->getState($stateful));
 
@@ -34,22 +41,27 @@ class PropertyPathStateAccessorTest extends \PHPUnit_Framework_TestCase
         $this->propertyAccessor
             ->expects($this->at(0))
             ->method('getValue')
-            ->with($stateful, 'finiteState')
-            ->will($this->returnValue('foo'));
+            ->with(...[$stateful, 'finiteState'])
+            ->willReturn('foo')
+        ;
 
         $this->assertSame('foo', $object->getState($stateful));
     }
 
+    /**
+     * @throws \Finite\Exception\NoSuchPropertyException
+     */
     public function testSetState()
     {
-        $object   = new PropertyPathStateAccessor('bar', $this->propertyAccessor);
-        $stateful = $this->getMock('Finite\StatefulInterface');
+        $object = new PropertyPathStateAccessor('bar', $this->propertyAccessor);
+        $stateful = $this->createMock(StatefulInterface::class);
 
         $this->propertyAccessor
             ->expects($this->at(0))
             ->method('setValue')
-            ->with($stateful, 'bar', 'foo')
-            ->will($this->returnValue('foo'));
+            ->with(...[$stateful, 'bar', 'foo'])
+            ->willReturn('foo')
+        ;
 
         $object->setState($stateful, 'foo');
 
@@ -57,44 +69,49 @@ class PropertyPathStateAccessorTest extends \PHPUnit_Framework_TestCase
         $this->propertyAccessor
             ->expects($this->at(0))
             ->method('setValue')
-            ->with($stateful, 'finiteState')
-            ->will($this->returnValue('foo'));
+            ->with(...[$stateful, 'finiteState'])
+            ->willReturn('foo')
+        ;
 
         $object->setState($stateful, 'foo');
     }
 
     /**
-     * @expectedException \Finite\Exception\NoSuchPropertyException
+     * @throws \Finite\Exception\NoSuchPropertyException
      */
     public function testSetOnUnknownProperty()
     {
-        $object   = new PropertyPathStateAccessor('bar', $this->propertyAccessor);
-        $stateful = $this->getMock('Finite\StatefulInterface');
+        $this->expectException(\Finite\Exception\NoSuchPropertyException::class);
+
+        $object = new PropertyPathStateAccessor('bar', $this->propertyAccessor);
+        $stateful = $this->createMock(StatefulInterface::class);
 
         $this->propertyAccessor
             ->expects($this->once())
             ->method('setValue')
-            ->with($stateful, 'bar', 'foo')
-            ->will($this->throwException(new NoSuchPropertyException));
-
+            ->with(...[$stateful, 'bar', 'foo'])
+            ->willThrowException(new NoSuchPropertyException)
+        ;
 
         $object->setState($stateful, 'foo');
     }
 
     /**
-     * @expectedException \Finite\Exception\NoSuchPropertyException
+     * @throws \Finite\Exception\NoSuchPropertyException
      */
     public function testGetOnUnknownProperty()
     {
-        $object   = new PropertyPathStateAccessor('bar', $this->propertyAccessor);
-        $stateful = $this->getMock('Finite\StatefulInterface');
+        $this->expectException(\Finite\Exception\NoSuchPropertyException::class);
+
+        $object = new PropertyPathStateAccessor('bar', $this->propertyAccessor);
+        $stateful = $this->createMock(StatefulInterface::class);
 
         $this->propertyAccessor
             ->expects($this->once())
             ->method('getValue')
-            ->with($stateful, 'bar')
-            ->will($this->throwException(new NoSuchPropertyException));
-
+            ->with(...[$stateful, 'bar'])
+            ->willThrowException(new NoSuchPropertyException)
+        ;
 
         $object->getState($stateful);
     }

--- a/tests/Finite/Test/State/StateTest.php
+++ b/tests/Finite/Test/State/StateTest.php
@@ -3,13 +3,15 @@
 namespace Finite\Test\State;
 
 use Finite\State\State;
+use Finite\Transition\TransitionInterface;
+use PHPUnit_Framework_TestCase;
 
 /**
  *
  *
  * @author Yohan Giarelli <yohan@frequence-web.fr>
  */
-class StateTest extends \PHPUnit_Framework_TestCase
+class StateTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var State
@@ -35,6 +37,9 @@ class StateTest extends \PHPUnit_Framework_TestCase
     /**
      * @depends      testAddTransition
      * @dataProvider testCanDataProvider
+     * @param $transitions
+     * @param $can
+     * @param $cannot
      */
     public function testCan($transitions, $can, $cannot)
     {
@@ -48,24 +53,24 @@ class StateTest extends \PHPUnit_Framework_TestCase
 
     public function testCanDataProvider()
     {
-        return array(
-            array(array('t1', 't2', 't3'), 't3', 't4'),
-            array(array('t1', 't2'), 't2', 't3'),
-        );
+        return [
+            [['t1', 't2', 't3'], 't3', 't4'],
+            [['t1', 't2'], 't2', 't3'],
+        ];
     }
-    
+
     /**
      * @param string $transitionName
      *
-     * @return \PHPUnit_Framework_MockObject_Builder_InvocationMocker
+     * @return \Finite\Transition\TransitionInterface|\PHPUnit_Framework_MockObject_Builder_InvocationMocker|\PHPUnit_Framework_MockObject_MockObject
      */
     private function getTransitionMock($transitionName)
     {
-        $transition = $this->getMock('\Finite\Transition\TransitionInterface');
+        $transition = $this->createMock(TransitionInterface::class);
 
         $transition->expects($this->once())
             ->method('getName')
-            ->will($this->returnValue($transitionName))
+            ->willReturn($transitionName)
         ;
 
         return $transition;

--- a/tests/Finite/Test/StateMachine/ListenableStateMachineTest.php
+++ b/tests/Finite/Test/StateMachine/ListenableStateMachineTest.php
@@ -2,6 +2,8 @@
 
 namespace Finite\Test\StateMachine;
 
+use Finite\Event\StateMachineEvent;
+use Finite\Event\TransitionEvent;
 use Finite\StateMachine\ListenableStateMachine;
 use Finite\Test\StateMachineTestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -25,90 +27,123 @@ class ListenableStateMachineTest extends StateMachineTestCase
     {
         parent::setUp();
 
-        $this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
+        $this->dispatcher = $this->getMockBuilder(EventDispatcher::class)
             ->disableOriginalConstructor()
-            ->getMock();
+            ->getMock()
+        ;
 
         $this->object = new ListenableStateMachine(null, $this->dispatcher, $this->accessor);
     }
 
+    /**
+     * @throws \Finite\Exception\ObjectException
+     */
     public function testInitialize()
     {
         $this->dispatcher
             ->expects($this->once())
             ->method('dispatch')
-            ->with('finite.initialize', $this->isInstanceOf('Finite\Event\StateMachineEvent'));
+            ->with(...['finite.initialize', $this->isInstanceOf(StateMachineEvent::class)])
+        ;
 
         $this->initialize();
     }
 
+    /**
+     * @throws \Finite\Exception\ObjectException
+     * @throws \Finite\Exception\StateException
+     */
     public function testApply()
     {
         $this->dispatcher
             ->expects($this->at(1))
             ->method('dispatch')
-            ->with('finite.test_transition', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.test_transition', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(2))
             ->method('dispatch')
-            ->with('finite.test_transition.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.test_transition.t23', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(3))
             ->method('dispatch')
-            ->with('finite.pre_transition', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.pre_transition', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(4))
             ->method('dispatch')
-            ->with('finite.pre_transition.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.pre_transition.t23', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(5))
             ->method('dispatch')
-            ->with('finite.post_transition', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.post_transition', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(6))
             ->method('dispatch')
-            ->with('finite.post_transition.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.post_transition.t23', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->initialize();
         $this->object->apply('t23');
     }
 
+    /**
+     * @throws \Finite\Exception\ObjectException
+     */
     public function testCan()
     {
         $this->dispatcher
             ->expects($this->at(1))
             ->method('dispatch')
-            ->with('finite.test_transition', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.test_transition', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(2))
             ->method('dispatch')
-            ->with('finite.test_transition.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.test_transition.t23', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->initialize();
         $this->assertFalse($this->object->can('t34'));
         $this->assertTrue($this->object->can('t23'));
     }
 
+    /**
+     * @throws \Finite\Exception\ObjectException
+     */
     public function testCanWithListener()
     {
         $this->dispatcher
             ->expects($this->at(1))
             ->method('dispatch')
-            ->with('finite.test_transition', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.test_transition', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(2))
             ->method('dispatch')
-            ->with('finite.test_transition.t23', $this->callback(function($event) {
-                $event->reject();
-                return $event instanceof \Finite\Event\TransitionEvent;
-            }));
+            ->with(
+                ...[
+                       'finite.test_transition.t23',
+                       $this->callback(
+                           static function ($event) {
+                               $event->reject();
+
+                               return $event instanceof TransitionEvent;
+                           }
+                       ),
+                   ]
+            )
+        ;
 
         $this->initialize();
         $this->assertFalse($this->object->can('t34'));

--- a/tests/Finite/Test/StateMachine/SecurityAwareStateMachineTest.php
+++ b/tests/Finite/Test/StateMachine/SecurityAwareStateMachineTest.php
@@ -2,24 +2,35 @@
 
 namespace Finite\Test\StateMachine;
 
+use Finite\State\Accessor\StateAccessorInterface;
+use Finite\StatefulInterface;
 use Finite\StateMachine\SecurityAwareStateMachine;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * @author Yohan Giarelli <yohan@frequence-web.fr>
  */
-class SecurityAwareStateMachineTest extends \PHPUnit_Framework_TestCase
+class SecurityAwareStateMachineTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var SecurityAwareStateMachine
      */
     protected $object;
+
     protected $accessor;
 
+    /**
+     * @throws \Finite\Exception\ObjectException
+     */
     public function setUp()
     {
-        $this->accessor = $this->getMock('Finite\State\Accessor\StateAccessorInterface');
-        $statefulMock = $this->getMock('Finite\StatefulInterface');
-        $this->accessor->expects($this->at(0))->method('getState')->will($this->returnValue('s1'));
+        $this->accessor = $this->createMock(StateAccessorInterface::class);
+        $statefulMock = $this->createMock(StatefulInterface::class);
+        $this->accessor->expects($this->at(0))
+            ->method('getState')
+            ->willReturn('s1')
+        ;
 
         $this->object = new SecurityAwareStateMachine($statefulMock, null, $this->accessor);
         $this->object->addTransition('t12', 's1', 's2');
@@ -29,19 +40,20 @@ class SecurityAwareStateMachineTest extends \PHPUnit_Framework_TestCase
 
     public function testCan()
     {
-        $securityMock = $this->getMock('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface');
+        $securityMock = $this->createMock(AuthorizationCheckerInterface::class);
         $this->object->setSecurityContext($securityMock);
 
-        $that     = $this;
+        $that = $this;
         $stateful = $this->object->getObject();
-        $addIsGrandedExpectation = function($return, $transition) use ($that, $securityMock, $stateful) {
+        $addIsGrandedExpectation = static function ($return, $transition) use ($that, $securityMock, $stateful) {
             static $at = 0;
 
             $securityMock
                 ->expects($that->at($at++))
                 ->method('isGranted')
-                ->with($transition, $stateful)
-                ->will($that->returnValue($return));
+                ->with(...[$transition, $stateful])
+                ->willReturn($return)
+            ;
         };
 
         $addIsGrandedExpectation(true, 't12');
@@ -54,5 +66,4 @@ class SecurityAwareStateMachineTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->object->can('t12'));
         $this->assertFalse($this->object->can('t23'));
     }
-
 }

--- a/tests/Finite/Test/StateMachine/StateMachineTest.php
+++ b/tests/Finite/Test/StateMachine/StateMachineTest.php
@@ -2,9 +2,14 @@
 
 namespace Finite\Test\StateMachine;
 
+use Finite\Event\StateMachineEvent;
+use Finite\Event\TransitionEvent;
+use Finite\Exception\StateException;
 use Finite\State\State;
-use Finite\StateMachine\StateMachine;
+use Finite\State\StateInterface;
+use Finite\StatefulInterface;
 use Finite\Test\StateMachineTestCase;
+use Finite\Transition\TransitionInterface;
 
 /**
  * @author Yohan Giarelli <yohan@frequence-web.fr>
@@ -14,33 +19,34 @@ class StateMachineTest extends StateMachineTestCase
     public function testAddState()
     {
         $this->object->addState('foo');
-        $this->assertInstanceOf('Finite\State\StateInterface', $this->object->getState('foo'));
+        $this->assertInstanceOf(StateInterface::class, $this->object->getState('foo'));
 
-        $stateMock = $this->getMock('Finite\State\StateInterface');
+        $stateMock = $this->createMock(StateInterface::class);
         $stateMock
             ->expects($this->once())
             ->method('getName')
-            ->will($this->returnValue('bar'));
+            ->willReturn('bar')
+        ;
 
         $this->object->addState($stateMock);
-        $this->assertInstanceOf('Finite\State\StateInterface', $this->object->getState('bar'));
+        $this->assertInstanceOf(StateInterface::class, $this->object->getState('bar'));
     }
 
     public function testAddTransition()
     {
         $this->object->addTransition('t12', 'state1', 'state2');
-        $this->assertInstanceOf('Finite\Transition\TransitionInterface', $this->object->getTransition('t12'));
+        $this->assertInstanceOf(TransitionInterface::class, $this->object->getTransition('t12'));
 
-        $transitionMock = $this->getMock('Finite\Transition\TransitionInterface');
+        $transitionMock = $this->createMock(TransitionInterface::class);
 
-        $transitionMock->expects($this->atLeastOnce())->method('getName')         ->will($this->returnValue('t23'));
-        $transitionMock->expects($this->once())       ->method('getInitialStates')->will($this->returnValue(array('state2')));
-        $transitionMock->expects($this->atLeastOnce())->method('getState')        ->will($this->returnValue('state3'));
+        $transitionMock->expects($this->atLeastOnce())->method('getName')->willReturn('t23');
+        $transitionMock->expects($this->once())->method('getInitialStates')->willReturn(['state2']);
+        $transitionMock->expects($this->atLeastOnce())->method('getState')->willReturn('state3');
 
         $this->object->addTransition($transitionMock);
-        $this->assertInstanceOf('Finite\Transition\TransitionInterface', $this->object->getTransition('t23'));
+        $this->assertInstanceOf(TransitionInterface::class, $this->object->getTransition('t23'));
 
-        $this->assertInstanceOf('Finite\State\StateInterface', $this->object->getState('state3'));
+        $this->assertInstanceOf(StateInterface::class, $this->object->getState('state3'));
     }
 
     public function testInitialize()
@@ -48,16 +54,17 @@ class StateMachineTest extends StateMachineTestCase
         $this->dispatcher
             ->expects($this->once())
             ->method('dispatch')
-            ->with('finite.initialize', $this->isInstanceOf('Finite\Event\StateMachineEvent'));
+            ->with(...['finite.initialize', $this->isInstanceOf(StateMachineEvent::class)])
+        ;
 
         $this->initialize();
     }
 
     public function testInitializeWithInitialState()
     {
-        $object = $this->getMock('Finite\StatefulInterface');
+        $object = $this->createMock(StatefulInterface::class);
 
-        $this->accessor->expects($this->at(1))->method('setState')->will($this->returnValue('s1'));
+        $this->accessor->expects($this->at(1))->method('setState')->willReturn('s1');
 
         $this->addStates();
         $this->addTransitions();
@@ -68,7 +75,7 @@ class StateMachineTest extends StateMachineTestCase
     public function testGetCurrentState()
     {
         $this->initialize();
-        $this->assertInstanceOf('Finite\State\StateInterface', $this->object->getCurrentState());
+        $this->assertInstanceOf(StateInterface::class, $this->object->getCurrentState());
         $this->assertSame('s2', $this->object->getCurrentState()->getName());
     }
 
@@ -81,74 +88,85 @@ class StateMachineTest extends StateMachineTestCase
 
     public function testCanWithGuardReturningFalse()
     {
-        $transition = $this->getMock('\Finite\Transition\TransitionInterface');
+        $transition = $this->createMock(TransitionInterface::class);
         $transition->expects($this->any())
             ->method('getGuard')
-            ->will($this->returnValue(function () {
-                return false;
-            }));
+            ->willReturn(
+                function () {
+                    return false;
+                }
+            )
+        ;
 
-        $transition->expects($this->atLeastOnce())->method('getName')         ->will($this->returnValue('t'));
-        $transition->expects($this->once())       ->method('getInitialStates')->will($this->returnValue(array('state1')));
+        $transition->expects($this->atLeastOnce())->method('getName')->willReturn('t');
+        $transition->expects($this->once())->method('getInitialStates')->willReturn(['state1']);
         $this->object->addTransition($transition);
         $this->assertFalse($this->object->can($transition));
     }
 
     public function testCanWithGuardReturningTrue()
     {
-        $transition = $this->getMock('\Finite\Transition\TransitionInterface');
+        $transition = $this->createMock(TransitionInterface::class);
         $transition->expects($this->any())
             ->method('getGuard')
-            ->will($this->returnValue(function () {
-                return true;
-            }));
+            ->willReturn(
+                function () {
+                    return true;
+                }
+            )
+        ;
 
-        $stateful = $this->getMock('Finite\StatefulInterface');
+        $stateful = $this->createMock(StatefulInterface::class);
         $this->object->addState(new State('state1', State::TYPE_INITIAL));
 
         $this->object->setObject($stateful);
         $this->object->initialize();
-        $transition->expects($this->atLeastOnce())->method('getName')         ->will($this->returnValue('t'));
-        $transition->expects($this->once())       ->method('getInitialStates')->will($this->returnValue(array('state1')));
+        $transition->expects($this->atLeastOnce())->method('getName')->willReturn('t');
+        $transition->expects($this->once())->method('getInitialStates')->willReturn(['state1']);
         $this->object->addTransition($transition);
 
         $this->assertTrue($this->object->can($transition));
     }
 
-    /**
-     * @expectedException \Finite\Exception\StateException
-     */
     public function testApply()
     {
+        $this->expectException(StateException::class);
+
         $this->dispatcher
             ->expects($this->at(1))
             ->method('dispatch')
-            ->with('finite.test_transition', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.test_transition', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(2))
             ->method('dispatch')
-            ->with('finite.test_transition.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.test_transition.t23', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(3))
             ->method('dispatch')
-            ->with('finite.pre_transition', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.pre_transition', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(4))
             ->method('dispatch')
-            ->with('finite.pre_transition.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.pre_transition.t23', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(5))
             ->method('dispatch')
-            ->with('finite.post_transition', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.post_transition', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(6))
             ->method('dispatch')
-            ->with('finite.post_transition.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.post_transition.t23', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->initialize();
         $this->object->apply('t23');
@@ -160,24 +178,27 @@ class StateMachineTest extends StateMachineTestCase
     {
         $this->initialize();
 
-        $this->assertSame(array('s1', 's2', 's3', 's4', 's5'), $this->object->getStates());
+        $this->assertSame(['s1', 's2', 's3', 's4', 's5'], $this->object->getStates());
     }
 
     public function testGetTransitions()
     {
         $this->initialize();
 
-        $this->assertSame(array('t12', 't23', 't34', 't45'), $this->object->getTransitions());
+        $this->assertSame(['t12', 't23', 't34', 't45'], $this->object->getTransitions());
     }
 
     public function testGetStateFromObject()
     {
         $this->initialize();
 
-        $state = $this->getMock('stdClass', array('__toString'));
-        $state->expects($this->once())->method('__toString')->will($this->returnValue('s1'));
+        $state = $this->getMockBuilder('stdClass')
+            ->setMethods(['__toString'])
+            ->getMock()
+        ;
+        $state->expects($this->once())->method('__toString')->willReturn('s1');
 
-        $this->assertInstanceOf('Finite\State\State', $this->object->getState($state));
+        $this->assertInstanceOf(State::class, $this->object->getState($state));
     }
 
     /**
@@ -185,51 +206,59 @@ class StateMachineTest extends StateMachineTestCase
      */
     public function testApplyWithGraph()
     {
-
         $this->dispatcher
             ->expects($this->at(1))
             ->method('dispatch')
-            ->with('finite.test_transition', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.test_transition', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(2))
             ->method('dispatch')
-            ->with('finite.test_transition.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.test_transition.t23', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(3))
             ->method('dispatch')
-            ->with('finite.test_transition.foo.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.test_transition.foo.t23', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(4))
             ->method('dispatch')
-            ->with('finite.pre_transition', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.pre_transition', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(5))
             ->method('dispatch')
-            ->with('finite.pre_transition.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.pre_transition.t23', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(6))
             ->method('dispatch')
-            ->with('finite.pre_transition.foo.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.pre_transition.foo.t23', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(7))
             ->method('dispatch')
-            ->with('finite.post_transition', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.post_transition', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(8))
             ->method('dispatch')
-            ->with('finite.post_transition.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.post_transition.t23', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->dispatcher
             ->expects($this->at(9))
             ->method('dispatch')
-            ->with('finite.post_transition.foo.t23', $this->isInstanceOf('Finite\Event\TransitionEvent'));
+            ->with(...['finite.post_transition.foo.t23', $this->isInstanceOf(TransitionEvent::class)])
+        ;
 
         $this->object->setGraph('foo');
 
@@ -241,12 +270,12 @@ class StateMachineTest extends StateMachineTestCase
     public function testItFindsStatesByPropertyName()
     {
         $this->initialize();
-        $this->assertSame(array('s2', 's4', 's5'), $this->object->findStateWithProperty('visible'));
+        $this->assertSame(['s2', 's4', 's5'], $this->object->findStateWithProperty('visible'));
     }
 
     public function testItFindsStatesByPropertyValue()
     {
         $this->initialize();
-        $this->assertSame(array('s2', 's4'), $this->object->findStateWithProperty('visible', true));
+        $this->assertSame(['s2', 's4'], $this->object->findStateWithProperty('visible', true));
     }
 }

--- a/tests/Finite/Test/StateMachineTestCase.php
+++ b/tests/Finite/Test/StateMachineTestCase.php
@@ -2,13 +2,17 @@
 
 namespace Finite\Test;
 
+use Finite\State\Accessor\StateAccessorInterface;
 use Finite\State\State;
-use  Finite\StateMachine\StateMachine;
+use Finite\StatefulInterface;
+use Finite\StateMachine\StateMachine;
+use PHPUnit_Framework_TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 
 /**
  * @author Yohan Giarelli <yohan@frequence-web.fr>
  */
-class StateMachineTestCase extends \PHPUnit_Framework_TestCase
+class StateMachineTestCase extends PHPUnit_Framework_TestCase
 {
     /**
      * @var StateMachine
@@ -24,33 +28,34 @@ class StateMachineTestCase extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $this->accessor = $this->getMock('Finite\State\Accessor\StateAccessorInterface');
-        $this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')
+        $this->accessor = $this->createMock(StateAccessorInterface::class);
+        $this->dispatcher = $this->getMockBuilder(EventDispatcher::class)
             ->disableOriginalConstructor()
-            ->getMock();
+            ->getMock()
+        ;
 
         $this->object = new StateMachine(null, $this->dispatcher, $this->accessor);
     }
 
     public function statesProvider()
     {
-        return array(
-            array(new State('s1', State::TYPE_INITIAL)),
-            array(new State('s2', State::TYPE_NORMAL, array(), array('visible' => true))),
-            array('s3'),
-            array(new State('s4', State::TYPE_NORMAL, array(), array('visible' => true))),
-            array(new State('s5', State::TYPE_FINAL, array(), array('visible' => false))),
-        );
+        return [
+            [new State('s1', State::TYPE_INITIAL)],
+            [new State('s2', State::TYPE_NORMAL, [], ['visible' => true])],
+            ['s3'],
+            [new State('s4', State::TYPE_NORMAL, [], ['visible' => true])],
+            [new State('s5', State::TYPE_FINAL, [], ['visible' => false])],
+        ];
     }
 
     public function transitionsProvider()
     {
-        return array(
-            array('t12', 's1', 's2'),
-            array('t23', 's2', 's3'),
-            array('t34', 's3', 's4'),
-            array('t45', 's4', 's5'),
-        );
+        return [
+            ['t12', 's1', 's2'],
+            ['t23', 's2', 's3'],
+            ['t34', 's3', 's4'],
+            ['t45', 's4', 's5'],
+        ];
     }
 
     protected function addStates()
@@ -67,6 +72,9 @@ class StateMachineTestCase extends \PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @throws \Finite\Exception\ObjectException
+     */
     protected function initialize()
     {
         $this->addStates();
@@ -77,8 +85,8 @@ class StateMachineTestCase extends \PHPUnit_Framework_TestCase
 
     protected function getStatefulObjectMock()
     {
-        $mock = $this->getMock('Finite\StatefulInterface');
-        $this->accessor->expects($this->at(0))->method('getState')->will($this->returnValue('s2'));
+        $mock = $this->createMock(StatefulInterface::class);
+        $this->accessor->expects($this->at(0))->method('getState')->willReturn('s2');
 
         return $mock;
     }

--- a/tests/Finite/Test/Transition/TransitionTest.php
+++ b/tests/Finite/Test/Transition/TransitionTest.php
@@ -3,12 +3,13 @@
 namespace Finite\Test\Transition;
 
 use Finite\Transition\Transition;
+use PHPUnit_Framework_TestCase;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * @author Yohan Giarelli <yohan@giarel.li>
  */
-class TransitionTest extends \PHPUnit_Framework_TestCase
+class TransitionTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var Transition
@@ -22,30 +23,35 @@ class TransitionTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->optionsResolver = $this->getMockBuilder('Symfony\Component\OptionsResolver\OptionsResolver')
+        $this->optionsResolver = $this->getMockBuilder(OptionsResolver::class)
             ->disableOriginalConstructor()
-            ->getMock();
-        $this->object = new Transition('transition', array('s1'), 's2', null, $this->optionsResolver);
+            ->getMock()
+        ;
+        $this->object = new Transition('transition', ['s1'], 's2', null, $this->optionsResolver);
     }
 
+    /**
+     * @throws \Finite\Exception\TransitionException
+     */
     public function testItResolvesOptions()
     {
         $this->optionsResolver
             ->expects($this->once())
             ->method('resolve')
-            ->with($this->isType('array'))
-            ->will($this->returnValue(array('foo' => 'bar')));
+            ->with(...[$this->isType('array')])
+            ->willReturn(['foo' => 'bar'])
+        ;
 
-        $this->assertSame(array('foo' => 'bar'), $this->object->resolveProperties(array('baz' => 'qux')));
+        $this->assertSame(['foo' => 'bar'], $this->object->resolveProperties(['baz' => 'qux']));
     }
 
     public function testItReturnsDefaultOptions()
     {
         $resolver = new OptionsResolver;
-        $resolver->setDefaults(array('p1' => 'foo', 'p2' => 'bar'));
-        $transition = new Transition('transition', array('s1'), 's2', null, $resolver);
+        $resolver->setDefaults(['p1' => 'foo', 'p2' => 'bar']);
+        $transition = new Transition('transition', ['s1'], 's2', null, $resolver);
 
-        $this->assertSame(array('p1' => 'foo', 'p2' => 'bar'), $transition->getProperties());
+        $this->assertSame(['p1' => 'foo', 'p2' => 'bar'], $transition->getProperties());
         $this->assertTrue($transition->has('p1'));
         $this->assertFalse($transition->has('p3'));
         $this->assertSame('bar', $transition->get('p2'));
@@ -54,11 +60,11 @@ class TransitionTest extends \PHPUnit_Framework_TestCase
     public function testItReturnsDefaultOptionsWhenSomeRequired()
     {
         $resolver = new OptionsResolver;
-        $resolver->setDefaults(array('p1' => 'foo', 'p2' => 'bar'));
-        $resolver->setRequired(array('p3'));
-        $transition = new Transition('transition', array('s1'), 's2', null, $resolver);
+        $resolver->setDefaults(['p1' => 'foo', 'p2' => 'bar']);
+        $resolver->setRequired(['p3']);
+        $transition = new Transition('transition', ['s1'], 's2', null, $resolver);
 
-        $this->assertSame(array('p1' => 'foo', 'p2' => 'bar'), $transition->getProperties());
+        $this->assertSame(['p1' => 'foo', 'p2' => 'bar'], $transition->getProperties());
         $this->assertTrue($transition->has('p1'));
         $this->assertFalse($transition->has('p3'));
         $this->assertSame('bar', $transition->get('p2'));


### PR DESCRIPTION
Bump phpunit version to 5.7
Use PHP 5.6 new array syntax in tests
Use ::class instead of strings in mock builders
Fix phpunit deprecated methods usage in tests
Add latest PHP versions to .travis.yml