### PR TITLE
Prevent symfony/event-dispatcher great than 4.2 from being installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php":                      ">=5.5",
         "symfony/options-resolver": "^2.6|^3.0|^4.0",
-        "symfony/event-dispatcher": "^2.6|^3.0|^4.0",
+        "symfony/event-dispatcher": "^2.6|^3.0|~4.2.0",
         "symfony/property-access":  "^2.6|^3.0|^4.0"
     },
     "require-dev": {


### PR DESCRIPTION
This is in order to prevent the following notice from being thrown:

NoticedError: Calling the
"Symfony\Component\EventDispatcher\EventDispatcherInterface::dispatch()"
method with the event name as the first argument is deprecated since
Symfony 4.3, pass it as the second argument and provide the event object
as the first argument instead.